### PR TITLE
Updating password server error message for reuse issue

### DIFF
--- a/application/common/models/Password.php
+++ b/application/common/models/Password.php
@@ -179,7 +179,14 @@ class Password extends Model
                     1469194882
                 );
             } else {
-                throw new ServerErrorHttpException(\Yii::t('app', 'Unable to update password'), 1463165209);
+                throw new ServerErrorHttpException(
+                    \Yii::t(
+                        'app',
+                        'Unable to update password. ' .
+                            'If this password has been used before please use something different.'
+                    ), 
+                    1463165209
+                );
             }
 
         }


### PR DESCRIPTION
The PasswordReuseException is either not getting thrown properly or is not getting caught, so updating the default error when setting password fails on server to tell user not to try different password if current has been used. 