### PR TITLE
added env var to enable/disable requiring recaptcha, default is required

### DIFF
--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -22,6 +22,7 @@ $fromName = Env::get('FROM_NAME');
 $appEnv = Env::get('APP_ENV');
 $idpName = Env::get('IDP_NAME');
 $idpUsernameHint = Env::get('IDP_USERNAME_HINT', $idpName . ' username, ex: first_last');
+$recaptchaRequired = Env::get('RECAPTCHA_REQUIRED', true);
 $recaptchaSiteKey = Env::get('RECAPTCHA_SITE_KEY');
 $recaptchaSecretKey = Env::get('RECAPTCHA_SECRET_KEY');
 $uiUrl = Env::get('UI_URL');
@@ -200,6 +201,7 @@ return [
             ]
         ],
         'recaptcha' => [
+            'required' => $recaptchaRequired,
             'siteKey' => $recaptchaSiteKey,
             'secretKey' => $recaptchaSecretKey,
         ],

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -65,8 +65,12 @@ class ResetController extends BaseRestController
         $username = \Yii::$app->request->post('username');
         $verificationToken = \Yii::$app->request->post('verification_token');
 
-        if ( ! $username || ! $verificationToken) {
-            throw new BadRequestHttpException('Missing username or verification_token');
+        if ( ! $username) {
+            throw new BadRequestHttpException('Username is required');
+        }
+
+        if ( ! $verificationToken && \Yii::$app->params['recaptcha']['required']) {
+            throw new BadRequestHttpException('Recaptcha verification code is required');
         }
 
         /*

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -69,18 +69,20 @@ class ResetController extends BaseRestController
             throw new BadRequestHttpException('Username is required');
         }
 
-        if ( ! $verificationToken && \Yii::$app->params['recaptcha']['required']) {
-            throw new BadRequestHttpException('Recaptcha verification code is required');
-        }
-
         /*
          * Validate reCaptcha $verificationToken before proceeding.
          * This will throw an exception if not successful, checking response to
          * be double sure an exception is thrown.
          */
-        $clientIp = Utils::getClientIp(\Yii::$app->request);
-        if ( ! Utils::isRecaptchaResponseValid($verificationToken, $clientIp)) {
-            throw new BadRequestHttpException('reCaptcha failed verification');
+        if (\Yii::$app->params['recaptcha']['required']) {
+            if ( ! $verificationToken) {
+                throw new BadRequestHttpException('Recaptcha verification code is required');
+            }
+            
+            $clientIp = Utils::getClientIp(\Yii::$app->request);
+            if (!Utils::isRecaptchaResponseValid($verificationToken, $clientIp)) {
+                throw new BadRequestHttpException('reCaptcha failed verification');
+            }
         }
 
         /*

--- a/local.env.dist
+++ b/local.env.dist
@@ -7,6 +7,7 @@ ADMIN_EMAIL=
 FROM_EMAIL=
 FROM_NAME=Your friendly Help Desk team
 FRONT_COOKIE_SECURE=true
+RECAPTCHA_REQUIRED=true
 RECAPTCHA_SITE_KEY=
 RECAPTCHA_SECRET_KEY=
 COMPOSER_AUTH={"github-oauth":{"github.com":"tokenhere"}}


### PR DESCRIPTION
When running locally for dev without a UI its a pain to deal with recaptcha, this will allow disabling the requirement for it. I added it as a separate var rather than conditionally based on the recaptcha key and secret being present to ensure it is only disabled intentionally, not due to forgetting one of the other vars. 