### PR TITLE
Update SAML2 dependency

### DIFF
--- a/application/composer.lock
+++ b/application/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "17f06c3cb1ed0331cedeb69b77a1f687",
@@ -70,7 +70,7 @@
                 "issues": "https://github.com/Adldap2/Adldap2/issues",
                 "source": "https://github.com/Adldap2/Adldap2"
             },
-            "time": "2016-06-08 15:55:24"
+            "time": "2016-06-08T15:55:24+00:00"
         },
         {
             "name": "cebe/markdown",
@@ -1682,6 +1682,7 @@
                 "syslog",
                 "yii2"
             ],
+            "abandoned": "silinternational/yii2-json-log-targets",
             "time": "2015-08-19T15:07:38+00:00"
         },
         {
@@ -1765,16 +1766,16 @@
         },
         {
             "name": "simplesamlphp/saml2",
-            "version": "v2.3.4",
+            "version": "v2.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/saml2.git",
-                "reference": "967edad97f38578f9b4561d6f624c974dd2c14a9"
+                "reference": "5d69753a61b4bfb95eed3ea0c3f8cbb4e6e0ad2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/967edad97f38578f9b4561d6f624c974dd2c14a9",
-                "reference": "967edad97f38578f9b4561d6f624c974dd2c14a9",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/5d69753a61b4bfb95eed3ea0c3f8cbb4e6e0ad2f",
+                "reference": "5d69753a61b4bfb95eed3ea0c3f8cbb4e6e0ad2f",
                 "shasum": ""
             },
             "require": {
@@ -1804,7 +1805,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-2.1"
+                "LGPL-2.1-or-later"
             ],
             "authors": [
                 {
@@ -1813,7 +1814,7 @@
                 }
             ],
             "description": "SAML2 PHP library from SimpleSAMLphp",
-            "time": "2016-12-14T16:34:56+00:00"
+            "time": "2018-03-02T14:44:21+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -2500,7 +2501,7 @@
                 "phpmyadmin",
                 "web"
             ],
-            "time": "2016-11-16 16:03:54"
+            "time": "2016-11-16T16:03:54+00:00"
         },
         {
             "name": "fzaninotto/faker",


### PR DESCRIPTION
This is to update the simplesamlphp/saml2 library in our legacy version of idp-pw-api.