### PR TITLE
Release `legacy.2.0`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -39,9 +39,6 @@ Vagrant.configure(2) do |config|
   # View the documentation for the provider you are using for more
   # information on available options.
 
-  # Set synced folder permissions
-  config.vm.synced_folder "./", "/vagrant", :mount_options => [ "dmode=755,fmode=755," ], owner: 33, group: 33
-
   # This provisioner runs on the first `vagrant up`.
   config.vm.provision "install", type: "shell", inline: <<-SHELL
     # Add Docker apt repository

--- a/application/composer.json
+++ b/application/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "yiisoft/yii2": "2.0.11.2",
+    "yiisoft/yii2": "~2.0.15",
     "yiisoft/yii2-swiftmailer": "*",
     "yiisoft/yii2-gii": "*",
     "silinternational/php-env": "^2.1.0",

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17f06c3cb1ed0331cedeb69b77a1f687",
+    "content-hash": "6d2d9a8b6278268a63deb8824aedadd6",
     "packages": [
         {
             "name": "adldap2/adldap2",
@@ -74,16 +74,16 @@
         },
         {
             "name": "cebe/markdown",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cebe/markdown.git",
-                "reference": "c30eb5e01fe021cc5bba2f9ee0eeef96d4931166"
+                "reference": "25b28bae8a6f185b5030673af77b32e1163d5c6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cebe/markdown/zipball/c30eb5e01fe021cc5bba2f9ee0eeef96d4931166",
-                "reference": "c30eb5e01fe021cc5bba2f9ee0eeef96d4931166",
+                "url": "https://api.github.com/repos/cebe/markdown/zipball/25b28bae8a6f185b5030673af77b32e1163d5c6e",
+                "reference": "25b28bae8a6f185b5030673af77b32e1163d5c6e",
                 "shasum": ""
             },
             "require": {
@@ -130,7 +130,7 @@
                 "markdown",
                 "markdown-extra"
             ],
-            "time": "2016-09-14T20:40:20+00:00"
+            "time": "2017-07-16T21:13:23+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -201,16 +201,16 @@
         },
         {
             "name": "ezyang/htmlpurifier",
-            "version": "v4.9.3",
+            "version": "v4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "95e1bae3182efc0f3422896a3236e991049dac69"
+                "reference": "d85d39da4576a6934b72480be6978fb10c860021"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/95e1bae3182efc0f3422896a3236e991049dac69",
-                "reference": "95e1bae3182efc0f3422896a3236e991049dac69",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/d85d39da4576a6934b72480be6978fb10c860021",
+                "reference": "d85d39da4576a6934b72480be6978fb10c860021",
                 "shasum": ""
             },
             "require": {
@@ -244,24 +244,25 @@
             "keywords": [
                 "html"
             ],
-            "time": "2017-06-03T02:28:16+00:00"
+            "time": "2018-02-23T01:58:20+00:00"
         },
         {
             "name": "fillup/fake-bower-assets",
-            "version": "2.0.9",
+            "version": "2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fillup/fake-bower-assets.git",
-                "reference": "9845d8e91eea0922fd6446ba99c68682c9f46a38"
+                "reference": "05ca2ac45757cee3906d6056c9623585c1eea68b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fillup/fake-bower-assets/zipball/9845d8e91eea0922fd6446ba99c68682c9f46a38",
-                "reference": "9845d8e91eea0922fd6446ba99c68682c9f46a38",
+                "url": "https://api.github.com/repos/fillup/fake-bower-assets/zipball/05ca2ac45757cee3906d6056c9623585c1eea68b",
+                "reference": "05ca2ac45757cee3906d6056c9623585c1eea68b",
                 "shasum": ""
             },
             "replace": {
                 "bower-asset/bootstrap": "3.3.6",
+                "bower-asset/inputmask": "3.2.2",
                 "bower-asset/jquery": "2.2.2",
                 "bower-asset/jquery.inputmask": "3.2.2",
                 "bower-asset/punycode": "1.3.1",
@@ -281,7 +282,7 @@
                 }
             ],
             "description": "Use Composer \"replace\" to fake out installing bower-asset dependencies that aren't really needed",
-            "time": "2016-07-27T13:10:36+00:00"
+            "time": "2018-05-08T17:44:00+00:00"
         },
         {
             "name": "fillup/nexmo",
@@ -1872,21 +1873,21 @@
         },
         {
             "name": "yiisoft/yii2",
-            "version": "2.0.11.2",
+            "version": "2.0.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/yii2-framework.git",
-                "reference": "ee996adec1dfd7babb67bd0c604f5bd6425fe5ab"
+                "reference": "ed3a9e1c4abe206e1c3ce48a6b3624119b79850d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii2-framework/zipball/ee996adec1dfd7babb67bd0c604f5bd6425fe5ab",
-                "reference": "ee996adec1dfd7babb67bd0c604f5bd6425fe5ab",
+                "url": "https://api.github.com/repos/yiisoft/yii2-framework/zipball/ed3a9e1c4abe206e1c3ce48a6b3624119b79850d",
+                "reference": "ed3a9e1c4abe206e1c3ce48a6b3624119b79850d",
                 "shasum": ""
             },
             "require": {
-                "bower-asset/jquery": "2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
-                "bower-asset/jquery.inputmask": "~3.2.2 | ~3.3.3",
+                "bower-asset/inputmask": "~3.2.2 | ~3.3.5",
+                "bower-asset/jquery": "3.2.*@stable | 3.1.*@stable | 2.2.*@stable | 2.1.*@stable | 1.11.*@stable | 1.12.*@stable",
                 "bower-asset/punycode": "1.3.*",
                 "bower-asset/yii2-pjax": "~2.0.1",
                 "cebe/markdown": "~1.0.0 | ~1.1.0",
@@ -1968,20 +1969,20 @@
                 "framework",
                 "yii2"
             ],
-            "time": "2017-02-08T09:04:32+00:00"
+            "time": "2018-03-21T18:36:53+00:00"
         },
         {
             "name": "yiisoft/yii2-composer",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/yii2-composer.git",
-                "reference": "3f4923c2bde6caf3f5b88cc22fdd5770f52f8df2"
+                "reference": "163419f1f197e02f015713b0d4f85598d8f8aa80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii2-composer/zipball/3f4923c2bde6caf3f5b88cc22fdd5770f52f8df2",
-                "reference": "3f4923c2bde6caf3f5b88cc22fdd5770f52f8df2",
+                "url": "https://api.github.com/repos/yiisoft/yii2-composer/zipball/163419f1f197e02f015713b0d4f85598d8f8aa80",
+                "reference": "163419f1f197e02f015713b0d4f85598d8f8aa80",
                 "shasum": ""
             },
             "require": {
@@ -2010,6 +2011,10 @@
                 {
                     "name": "Qiang Xue",
                     "email": "qiang.xue@gmail.com"
+                },
+                {
+                    "name": "Carsten Brandt",
+                    "email": "mail@cebe.cc"
                 }
             ],
             "description": "The composer plugin for Yii extension installer",
@@ -2018,7 +2023,7 @@
                 "extension installer",
                 "yii2"
             ],
-            "time": "2016-12-20T13:26:02+00:00"
+            "time": "2018-03-21T16:15:55+00:00"
         },
         {
             "name": "yiisoft/yii2-gii",

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -4,6 +4,7 @@ use Sil\PhpEnv\Env;
 
 /* Get frontend-specific config settings from ENV vars or set defaults. */
 $frontCookieSecure = Env::get('FRONT_COOKIE_SECURE', true);
+$cookieValidationKey = Env::get('COOKIE_VALIDATION_KEY');
 
 $sessionLifetime = 1800; // 30 minutes
 
@@ -36,6 +37,8 @@ return [
             'errorAction' => 'site/error',
         ],
         'request' => [
+            'cookieValidationKey' => $cookieValidationKey,
+            'enableCookieValidation' => !empty($cookieValidationKey),
             'enableCsrfValidation' => false,
             'parsers' => [
                 'application/json' => 'yii\web\JsonParser',

--- a/application/tests/api/FixtureHelper.php
+++ b/application/tests/api/FixtureHelper.php
@@ -37,6 +37,7 @@ class FixtureHelper extends Module
      */
     public function _beforeSuite($settings = [])
     {
+        $this->unloadFixtures();
         $this->loadFixtures();
     }
 

--- a/local.env.dist
+++ b/local.env.dist
@@ -12,6 +12,7 @@ RECAPTCHA_SITE_KEY=
 RECAPTCHA_SECRET_KEY=
 COMPOSER_AUTH={"github-oauth":{"github.com":"tokenhere"}}
 COMPOSER_CACHE_DIR=/tmp
+COOKIE_VALIDATION_KEY=
 UI_URL=http://idp-pw.local/#
 UI_CORS_ORIGIN=http://idp-pw.local
 HELP_CENTER_URL=https://google.com/


### PR DESCRIPTION
**Summary:**
* Update Yii2 to a non-vulnerable version
* Add optional `COOKIE_VALIDATION_KEY` env. var
* Fix tests (by unloading fixtures before reloading them)

These are all changes that we have already done on our current (aka. non-legacy) branch of this code.

Since this does add a new feature (cookie validation), I'm bumping the middle "number" of the version (`legacy.1.1` to `legacy.2.0`).