### PR TITLE
Change personnel namespace to lowercase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ testapi: upTestDb brokerDb broker yiimigratetestDb yiimigratetestDblocal
 	docker-compose up -d zxcvbn
 	docker-compose run --rm apitest
 
-api: upDb composer yiimigrate yiimigratelocal
+api: upDb brokerDb broker composer yiimigrate yiimigratelocal
 	docker-compose up -d api zxcvbn cron phpmyadmin
 
 composer:
@@ -74,4 +74,4 @@ bounce:
 
 clean:
 	docker-compose kill
-	docker-compose rm
+	docker-compose rm -f

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can store your passwords wherever you like, whether it is LDAP, Active Direc
 The personnel component is used to look up informaton about users from your company's personnel system. This includes verifying that they are an active employee, getting information about them like name, email, employee id, whether they have a supervisor and what their supervisors email address is. If the personnel system is aware of spouses it can also provide the spouse's email address.
 
 * Component ID: ```personnel```
-* Implement interface: ```common\components\Personnel\PersonnelInterface```
+* Implement interface: ```common\components\personnel\PersonnelInterface```
 * Example implementation: [idp-pw-api-personnel-insite](https://github.com/silinternational/idp-pw-api-personnel-insite)
 
 ### Phone Verification Component

--- a/application/common/components/personnel/IdBroker.php
+++ b/application/common/components/personnel/IdBroker.php
@@ -1,5 +1,5 @@
 <?php
-namespace common\components\Personnel;
+namespace common\components\personnel;
 
 use IPBlock;
 use Sil\Idp\IdBroker\Client\IdBrokerClient;

--- a/application/common/components/personnel/NotFoundException.php
+++ b/application/common/components/personnel/NotFoundException.php
@@ -1,5 +1,5 @@
 <?php
-namespace common\components\Personnel;
+namespace common\components\personnel;
 
 class NotFoundException extends \Exception
 {

--- a/application/common/components/personnel/PersonnelInterface.php
+++ b/application/common/components/personnel/PersonnelInterface.php
@@ -1,9 +1,9 @@
 <?php
-namespace common\components\Personnel;
+namespace common\components\personnel;
 
 /**
  * Interface PersonnelInterface
- * @package common\components\Personnel
+ * @package common\components\personnel
  */
 interface PersonnelInterface
 {

--- a/application/common/components/personnel/PersonnelUser.php
+++ b/application/common/components/personnel/PersonnelUser.php
@@ -1,9 +1,9 @@
 <?php
-namespace common\components\Personnel;
+namespace common\components\personnel;
 
 /**
  * Class PersonnelUser
- * @package common\components\Personnel
+ * @package common\components\personnel
  */
 class PersonnelUser
 {

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -207,7 +207,7 @@ return [
             ],
         ],
         'personnel' => ArrayHelper::merge(
-            ['class' => 'common\components\Personnel\IdBroker'],
+            ['class' => 'common\components\personnel\IdBroker'],
             Env::getArrayFromPrefix('ID_BROKER_')
         ),
         'auth' => ArrayHelper::merge(

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -3,9 +3,9 @@ namespace common\models;
 
 use common\components\auth\User as AuthUser;
 use Sil\IdpPw\Common\PasswordStore\UserPasswordMeta;
-use common\components\Personnel\NotFoundException;
-use common\components\Personnel\PersonnelInterface;
-use common\components\Personnel\PersonnelUser;
+use common\components\personnel\NotFoundException;
+use common\components\personnel\PersonnelInterface;
+use common\components\personnel\PersonnelUser;
 use common\helpers\Utils;
 use yii\helpers\ArrayHelper;
 use yii\web\BadRequestHttpException;

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -6,7 +6,7 @@ use common\models\EventLog;
 use common\models\Reset;
 use common\models\User;
 use frontend\components\BaseRestController;
-use common\components\Personnel\NotFoundException;
+use common\components\personnel\NotFoundException;
 use yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Json;

--- a/application/tests/mock/personnel/Component.php
+++ b/application/tests/mock/personnel/Component.php
@@ -1,9 +1,9 @@
 <?php
 namespace tests\mock\personnel;
 
-use common\components\Personnel\PersonnelInterface;
-use common\components\Personnel\PersonnelUser;
-use common\components\Personnel\NotFoundException;
+use common\components\personnel\PersonnelInterface;
+use common\components\personnel\PersonnelUser;
+use common\components\personnel\NotFoundException;
 use yii\base\Component as YiiComponent;
 
 class Component extends YiiComponent implements PersonnelInterface

--- a/application/tests/unit/common/components/IdBrokerTest.php
+++ b/application/tests/unit/common/components/IdBrokerTest.php
@@ -3,8 +3,8 @@ namespace tests\unit\common\components;
 
 use PHPUnit\Framework\TestCase;
 
-use common\components\Personnel\NotFoundException;
-use common\components\Personnel\IdBroker;
+use common\components\personnel\NotFoundException;
+use common\components\personnel\IdBroker;
 use Sil\Idp\IdBroker\Client\IdBrokerClient;
 
 class IdBrokerTest extends TestCase
@@ -83,7 +83,7 @@ class IdBrokerTest extends TestCase
     public function testReturnPersonnelUserFromResponse_Mocked() {
         $mockReturnValue = $this->getMockReturnValue();
         unset($mockReturnValue['email']);
-        $brokerMock = $this->getMockBuilder('common\components\Personnel\IdBroker')
+        $brokerMock = $this->getMockBuilder('common\components\personnel\IdBroker')
             ->setMethods(['callIdBrokerGetUser'])
             ->getMock();
         $brokerMock->expects($this->any())
@@ -101,7 +101,7 @@ class IdBrokerTest extends TestCase
     public function testFindByEmployeeId_Mocked()
     {
         $mockReturnValue = $this->getMockReturnValue();
-        $brokerMock = $this->getMockBuilder('common\components\Personnel\IdBroker')
+        $brokerMock = $this->getMockBuilder('common\components\personnel\IdBroker')
                            ->setMethods(['callIdBrokerGetUser'])
                            ->getMock();
         $brokerMock->expects($this->any())

--- a/application/tests/unit/common/models/UserTest.php
+++ b/application/tests/unit/common/models/UserTest.php
@@ -2,7 +2,7 @@
 namespace tests\unit\common\models;
 
 use common\models\PasswordChangeLog;
-use common\components\Personnel\PersonnelUser;
+use common\components\personnel\PersonnelUser;
 use common\models\Method;
 use common\models\Reset;
 use common\models\User;
@@ -113,7 +113,7 @@ class UserTest extends Test
 
     public function testFindOrCreateDoesntExist()
     {
-        $this->expectException(\common\components\Personnel\NotFoundException::class);
+        $this->expectException(\common\components\personnel\NotFoundException::class);
         User::findOrCreate('doesnt_exist');
     }
 
@@ -172,7 +172,7 @@ class UserTest extends Test
     {
         $user = $this->users('user1');
         $personnelData = $user->getPersonnelUser();
-        $this->assertInstanceOf('common\components\Personnel\PersonnelUser', $personnelData);
+        $this->assertInstanceOf('common\components\personnel\PersonnelUser', $personnelData);
     }
 
     public function testSupervisor()


### PR DESCRIPTION
While integrating external repos, I realized lowercase is more consistent with existing namespaces. This PR renames common/components/Personnel/* to common/components/personnel*