### PR TITLE
Random cleanup from external repo integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,19 @@ start: api
 test:
 	make testunit && make testapi && make testbehat
 
-testunit: composer emailcron rmTestDb upTestDb brokerDb broker yiimigratetestDb yiimigratetestDblocal
+testunit: composer emailcron rmTestDb upTestDb broker yiimigratetestDb
 	docker-compose run emailcron whenavail emaildb 3306 100 ./yii migrate --interactive=0
 	docker-compose run --rm cli bash -c 'MYSQL_HOST=testDb MYSQL_DATABASE=test ./vendor/bin/codecept run unit'
 
 # Run testunit first at least once. Otherwise, this will have 5 test failures.
-testapi: upTestDb brokerDb broker yiimigratetestDb yiimigratetestDblocal
+testapi: upTestDb broker yiimigratetestDb
 	docker-compose up -d zxcvbn
 	docker-compose run --rm apitest
 
 testbehat:
 	docker-compose run --rm cli bash -c './vendor/bin/behat --config=tests/features/behat.yml --strict'
 
-api: upDb brokerDb broker composer yiimigrate yiimigratelocal
+api: upDb broker composer yiimigrate
 	docker-compose up -d api zxcvbn cron phpmyadmin
 
 composer:
@@ -65,9 +65,6 @@ rmTestDb:
 
 upTestDb:
 	docker-compose up -d testDb
-
-brokerDb:
-	docker-compose up -d brokerDb
 
 broker:
 	docker-compose up -d broker

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Backend API for Identity Provider Password Management
 7. You should be able to access the API using a REST client or your browser
    at http://idp-pw-api.local:8080.
 8. You'll probably also want the web interface for this application which you can
-   clone at ```link coming soon```
+   clone at <https://github.com/silinternational/idp-pw-ui>
 
 ### Additional setup for Linux & Mac
 1. Add entry to ```/etc/hosts``` for ```127.0.0.1 idp-pw-api.local```
@@ -63,37 +63,37 @@ To simplify common tasks there is a Makefile in place. The most common tasks wil
 With the goal of being reusable, this application is developed with a component based architecture that allows swapping out specific components to suit your needs. All components must implement common interfaces to support this and new components can be developed to implement the interface as needed.
 
 ### Common Interfaces and Classes
-The interfaces for components as well as some common classes are maintained in the [idp-pw-api-common](https://github.com/silinternational/idp-pw-api-common) repository.
+The interfaces for the following components are stored within the [application/common/components](./application/common/components) source tree.
 
 ### Configuration
-All components must extend from [\yii\base\Component](http://www.yiiframework.com/doc-2.0/guide-structure-application-components.html) so that they can be configured in the ```components``` section of the application configuration. This also allows them to be accessed via ```\Yii::$app->componentId```. While each component has a defind interface for methods to implement, what properties it needs for configuration are up to each implementation as appropriate. See [our common/config/local.php.dist](https://github.com/silinternational/idp-pw-api/blob/develop/application/common/config/local.php.dist) for examples of configurations.
+All components must extend from [\yii\base\Component](http://www.yiiframework.com/doc-2.0/guide-structure-application-components.html) so that they can be configured in the ```components``` section of the application configuration. This also allows them to be accessed via ```\Yii::$app->componentId```. While each component has a defined interface for methods to implement, what properties it needs for configuration are up to each implementation as appropriate. See [our common/config/local.php.dist](https://github.com/silinternational/idp-pw-api/blob/develop/application/common/config/local.php.dist) for examples of configurations.
 
 ### Authentication Component
 We use SAML for authentication but this component can be replaced to support whatever method is needed. For example an auth component could be written to implement OAuth or use Google, etc.
 
 * Component ID: ```auth```
 * Implement interface: ```common\components\auth\AuthnInterface```
-* Example implementation: [idp-pw-api-auth-saml](https://github.com/silinternational/idp-pw-api-auth-saml)
+* [Example implementation](./common/components/auth/Saml.php)
 
 ### Password Store Component
 You can store your passwords wherever you like, whether it is LDAP, Active Directory, a database, or even Redis.
 
 * Component ID: ```passwordstore```
 * Implement interface: ```common\components\passwordStore\PasswordStoreInterface```
-* Example implementation: [idp-pw-api-passwordstore-ldap](https://github.com/silinternational/idp-pw-api-passwordstore-ldap)
+* [Example implementation](./common/components/passwordStore/Ldap.php)
 
 ### Personnel Component
 The personnel component is used to look up informaton about users from your company's personnel system. This includes verifying that they are an active employee, getting information about them like name, email, employee id, whether they have a supervisor and what their supervisors email address is. If the personnel system is aware of spouses it can also provide the spouse's email address.
 
 * Component ID: ```personnel```
 * Implement interface: ```common\components\personnel\PersonnelInterface```
-* Example implementation: [idp-pw-api-personnel-insite](https://github.com/silinternational/idp-pw-api-personnel-insite)
+* [Example implementation](./common/components/personnel/IdBroker.php)
 
 ### Phone Verification Component
 This component is used for performing phone based verification of users.
 
 * Component ID: ```phone```
 * Implement interface: ```common\components\phoneVerification\PhoneVerificationInterface```
-* Example implementation: [idp-pw-api-phoneverification-nexmo](https://github.com/silinternational/idp-pw-api-phoneverification-nexmo)
+* [Example implementation](./common/components/Base.php)
 
 The Nexmo implementation supports using either Nexmo Verify or Nexmo SMS services. Nexmo Verify can send SMS messages or make phone calls so it is nice when your users may or may not understand text messaging.

--- a/application/common/config/local.php.dist
+++ b/application/common/config/local.php.dist
@@ -61,9 +61,5 @@ return [
             'brand' => 'Verification',
             'from' => '',
         ],
-        'passwordStore' => ArrayHelper::merge(
-            ['class' => 'common\components\passwordStore\IdBroker'],
-            Env::getArrayFromPrefix('ID_BROKER_')
-        ),
     ],
 ];

--- a/application/run-tests-api.sh
+++ b/application/run-tests-api.sh
@@ -21,8 +21,7 @@ whenavail ${MYSQL_HOST} 3306 100 /data/yii migrate --interactive=0 --migrationPa
 runny apache2ctl start
 
 # Run codeception tests
-#whenavail broker 80 100 echo "broker ready"
-sleep 10
+whenavail broker 80 100 echo "broker ready"
 /data/vendor/bin/codecept run api -d
 
 

--- a/application/run-tests.sh
+++ b/application/run-tests.sh
@@ -28,17 +28,19 @@ TESTRESULTS_UNIT=$?
 runny ./vendor/bin/behat --config=tests/features/behat.yml --strict
 TESTRESULTS_BEHAT=$?
 
+## The ocular.php script sometimes works and sometimes hangs with no error message
+
 # Clone repo to get git parents
-cd /tmp
-rm -rf idp-pw-api/
-git clone https://github.com/silinternational/idp-pw-api.git
-cd idp-pw-api/
-PARENTS=`git log --pretty=%P -n 1 ${CI_COMMIT_ID}`
+#cd /tmp
+#rm -rf idp-pw-api/
+#git clone https://github.com/silinternational/idp-pw-api.git
+#cd idp-pw-api/
+#PARENTS=`git log --pretty=%P -n 1 ${CI_COMMIT_ID}`
 
 # Push coverage data to scrutinizer
-cd /data
-curl -Lo ocular.phar https://scrutinizer-ci.com/ocular.phar
-php ocular.phar code-coverage:upload --repository="g/silinternational/idp-pw-api" --revision="${CI_COMMIT_ID}" --parent="${PARENTS}" --format=php-clover -n -vvv tests/_output/coverage.xml
+#cd /data
+#curl -Lo ocular.phar https://scrutinizer-ci.com/ocular.phar
+#php ocular.phar code-coverage:upload --repository="g/silinternational/idp-pw-api" --revision="${CI_COMMIT_ID}" --parent="${PARENTS}" --format=php-clover -n -vvv tests/_output/coverage.xml
 
 # If unit tests fail, make sure to exit with error status
 if [[ "$TESTRESULTS_UNIT" -ne 0 ]]; then

--- a/application/run-tests.sh
+++ b/application/run-tests.sh
@@ -17,36 +17,34 @@ whenavail ${MYSQL_HOST} 3306 100 /data/yii migrate --interactive=0
 whenavail ${MYSQL_HOST} 3306 100 /data/yii migrate --interactive=0 --migrationPath=console/migrations-test
 
 # Install and enable xdebug for code coverage
-#apt-get install -y php5-xdebug git
-#php5enmod xdebug
+apt-get install -y php-xdebug
 
 # Run codeception tests
-#whenavail broker 80 100 echo "broker ready"
-sleep 10
-runny ./vendor/bin/codecept run unit
+whenavail broker 80 100 echo "broker ready"
+runny ./vendor/bin/codecept run unit --coverage --coverage-xml
+TESTRESULTS_UNIT=$?
 
 # Run behat tests
 runny ./vendor/bin/behat --config=tests/features/behat.yml --strict
+TESTRESULTS_BEHAT=$?
 
-##### Disabled reporting of code coverage on 3/30 because scrutinizer isnt working with it yet
+# Clone repo to get git parents
+cd /tmp
+rm -rf idp-pw-api/
+git clone https://github.com/silinternational/idp-pw-api.git
+cd idp-pw-api/
+PARENTS=`git log --pretty=%P -n 1 ${CI_COMMIT_ID}`
 
-#./vendor/bin/codecept run unit --coverage --coverage-xml
-#TESTRESULTS=$?
-#
+# Push coverage data to scrutinizer
+cd /data
+curl -Lo ocular.phar https://scrutinizer-ci.com/ocular.phar
+php ocular.phar code-coverage:upload --repository="g/silinternational/idp-pw-api" --revision="${CI_COMMIT_ID}" --parent="${PARENTS}" --format=php-clover -n -vvv tests/_output/coverage.xml
 
-## Clone repo to get git parents
-#cd /tmp
-#rm -rf idp-pw-api/
-#git clone https://github.com/silinternational/idp-pw-api.git
-#cd idp-pw-api/
-#PARENTS=`git log --pretty=%P -n 1 ${CI_COMMIT_ID}`
-#
-## Push coverage data to scrutinizer
-#cd /data
-#curl -Lo ocular.phar https://scrutinizer-ci.com/ocular.phar
-#php ocular.phar code-coverage:upload --repository="g/silinternational/idp-pw-api" --revision="${CI_COMMIT_ID}" --parent="${PARENTS}" --format=php-clover -n -vvv tests/_output/coverage.xml
-#
-## If unit tests fail, make sure to exit with error status
-#if [[ "$TESTRESULTS" -ne 0 ]]; then
-#    exit $TESTRESULTS
-#fi
+# If unit tests fail, make sure to exit with error status
+if [[ "$TESTRESULTS_UNIT" -ne 0 ]]; then
+    exit $TESTRESULTS_UNIT
+fi
+
+if [[ "$TESTRESULTS_BEHAT" -ne 0 ]]; then
+    exit $TESTRESULTS_BEHAT
+fi

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -16,10 +16,9 @@ api:
         image: silintl/idp-pw-api
         dockerfile_path: ./Dockerfile
         cached: true
-    links:
+    depends_on:
         - db
         - zxcvbn
-    depends_on:
         - broker
     environment:
         MYSQL_HOST: db

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -7,6 +7,7 @@
       steps:
         - name: unit test
           service: api
+          command: whenavail db 3306 100 /data/run-tests.sh
     - type: serial
       steps:
         - name: api test

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -7,7 +7,6 @@
       steps:
         - name: unit test
           service: api
-          command: whenavail db 3306 100 /data/run-tests.sh
     - type: serial
       steps:
         - name: api test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,10 @@ services:
         env_file:
             - ./common.env
             - ./local.env
+        environment:
+            AUTH_SAML_idpCertificate:
+            AUTH_SAML_spCertificate:
+            AUTH_SAML_spPrivateKey:
         command: /data/run-cron.sh
 
     apitest:


### PR DESCRIPTION
This PR is a collection of cleanup edits left over from integrating external "common" repos.
* `passwordStore` component need not be defined in `local.php`. Edited `local.php.dist` accordingly.
* Uses updated `whenavail` to wait for broker container to be ready when running tests. Previous version of `whenavail` didn't work with apache2 so a fixed `sleep 10` was used.
* Began work on pulling in Codeception test coverage data, but the upload script provided by Scrutinizer isn't working properly. Previously, Scrutinizer was generating test coverage, but it doesn't support a complex environment with multiple databases.
* Simplification of local test scripts.
* Updated README.
* Removed lengthy AUTH environment variables from `cron` container to silence useless `pam_env` warnings.
