### PR TITLE
Limit access if auth level is not login

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -68,7 +68,8 @@ class User extends UserBase implements IdentityInterface
             'email',
             'password_meta' => function($model) {
                 return $model->getPasswordMeta();
-            }
+            },
+            'auth_type'
         ];
     }
 
@@ -587,5 +588,10 @@ class User extends UserBase implements IdentityInterface
         }
 
         return $accessToken;
+    }
+
+    public function isAuthScopeFull()
+    {
+        return $this->auth_type === self::AUTH_TYPE_LOGIN;
     }
 }

--- a/application/frontend/controllers/MethodController.php
+++ b/application/frontend/controllers/MethodController.php
@@ -29,7 +29,10 @@ class MethodController extends BaseRestController
                 'rules' => [
                     [
                         'allow' => true,
-                        'roles' => ['@'],
+                        'matchCallback' => function () {
+                            $user = \Yii::$app->user->identity;
+                            return ($user->isAuthScopeFull());
+                        }
                     ],
                 ]
             ]

--- a/application/frontend/controllers/MfaController.php
+++ b/application/frontend/controllers/MfaController.php
@@ -25,7 +25,10 @@ class MfaController extends BaseRestController
                 'rules' => [
                     [
                         'allow' => true,
-                        'roles' => ['@'],
+                        'matchCallback' => function () {
+                            $user = \Yii::$app->user->identity;
+                            return ( $user->isAuthScopeFull());
+                        }
                     ],
                 ]
             ]

--- a/application/tests/api/MethodCest.php
+++ b/application/tests/api/MethodCest.php
@@ -68,6 +68,14 @@ class MethodCest extends BaseCest
         ]);
     }
 
+    public function test62(ApiTester $I)
+    {
+        $I->wantTo('check response for authenticated GET request to method for a user with auth_type=reset');
+        $I->haveHttpHeader('Authorization', 'Bearer user5');
+        $I->sendGET('/method');
+        $I->seeResponseCodeIs(403);
+    }
+
     public function test7(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated POST request for creating a new method');
@@ -95,6 +103,14 @@ class MethodCest extends BaseCest
         $I->seeResponseCodeIs(409);
     }
 
+    public function test84(ApiTester $I)
+    {
+        $I->wantTo('check response for authenticated POST request to method for a user with auth_type=reset');
+        $I->haveHttpHeader('Authorization', 'Bearer user5');
+        $I->sendPOST('/method',['type'=>'email','value'=>'email@example.com']);
+        $I->seeResponseCodeIs(403);
+    }
+
     public function test9(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated GET request to obtain a method');
@@ -113,6 +129,14 @@ class MethodCest extends BaseCest
             'type' => "phone",
             'value' => "1,1234567890"
         ]);
+    }
+
+    public function test102(ApiTester $I)
+    {
+        $I->wantTo('check response for authenticated GET request to method/{uid} for a user with auth_type=reset');
+        $I->haveHttpHeader('Authorization', 'Bearer user5');
+        $I->sendGET('/method/55555555555555555555555555555555');
+        $I->seeResponseCodeIs(403);
     }
 
     public function test11(ApiTester $I)
@@ -205,7 +229,7 @@ class MethodCest extends BaseCest
 
     public function test157(ApiTester $I)
     {
-        $I->wantTo('check response when making multiple authenticated PUT request with invalid code and unexpired verification time when tyring to update a method');
+        $I->wantTo('check response when making multiple authenticated PUT request with invalid code and unexpired verification time when trying to update a method');
         $I->haveHttpHeader('Authorization', 'Bearer user1');
         $I->sendPUT('/method/33333333333333333333333333333335',['code'=>'13245']);
         $I->seeResponseCodeIs(400);
@@ -231,6 +255,14 @@ class MethodCest extends BaseCest
         $I->seeResponseCodeIs(429);
     }
 
+    public function test158(ApiTester $I)
+    {
+        $I->wantTo('check response for authenticated PUT request to method/{uid} for a user with auth_type=reset');
+        $I->haveHttpHeader('Authorization', 'Bearer user5');
+        $I->sendPUT('/method/55555555555555555555555555555555');
+        $I->seeResponseCodeIs(403);
+    }
+
     public function test16(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated DELETE request to method/id');
@@ -254,6 +286,14 @@ class MethodCest extends BaseCest
         $I->haveHttpHeader('Authorization', 'Bearer user2');
         $I->sendDELETE('/method/11111111111111111111111111111111');
         $I->seeResponseCodeIs(404);
+    }
+
+    public function test174(ApiTester $I)
+    {
+        $I->wantTo('check response for authenticated DELETE request to method/{uid} for a user with auth_type=reset');
+        $I->haveHttpHeader('Authorization', 'Bearer user5');
+        $I->sendDELETE('/method/55555555555555555555555555555555');
+        $I->seeResponseCodeIs(403);
     }
 
     public function test18(ApiTester $I)

--- a/application/tests/api/PasswordCest.php
+++ b/application/tests/api/PasswordCest.php
@@ -14,7 +14,7 @@ class PasswordCest extends BaseCest
     public function test2(ApiTester $I)
     {
         $I->wantTo('check response when making GET request with incorrect token for obtaining info about password');
-        $I->haveHttpHeader('Authorization', 'Bearer user11');
+        $I->haveHttpHeader('Authorization', 'Bearer invalidToken');
         $I->sendGET('/password');
         $I->seeResponseCodeIs(401);
     }
@@ -42,7 +42,7 @@ class PasswordCest extends BaseCest
     public function test5(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated POST request to /password');
-        $I->haveHttpHeader('Authorization', 'Bearer user11');
+        $I->haveHttpHeader('Authorization', 'Bearer invalidToken');
         $I->sendPOST('/password');
         $I->seeResponseCodeIs(401);
     }
@@ -66,7 +66,7 @@ class PasswordCest extends BaseCest
     public function test8(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated DELETE request to /password');
-        $I->haveHttpHeader('Authorization', 'Bearer user11');
+        $I->haveHttpHeader('Authorization', 'Bearer invalidToken');
         $I->sendDELETE('/password');
         $I->seeResponseCodeIs(401);
     }
@@ -74,7 +74,7 @@ class PasswordCest extends BaseCest
     public function test9(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated PATCH request to /password');
-        $I->haveHttpHeader('Authorization', 'Bearer user11');
+        $I->haveHttpHeader('Authorization', 'Bearer invalidToken');
         $I->sendPATCH('/password');
         $I->seeResponseCodeIs(401);
     }
@@ -90,7 +90,7 @@ class PasswordCest extends BaseCest
     public function test11(ApiTester $I)
     {
         $I->wantTo('check response when making authenticated OPTIONS request to /password');
-        $I->haveHttpHeader('Authorization', 'Bearer user11');
+        $I->haveHttpHeader('Authorization', 'Bearer invalidToken');
         $I->sendOPTIONS('/password');
         $I->seeResponseCodeIs(200);
     }

--- a/application/tests/api/UserCest.php
+++ b/application/tests/api/UserCest.php
@@ -21,7 +21,7 @@ class UserCest extends BaseCest
     public function test2(ApiTester $I)
     {
         $I->wantTo('check response when making GET request to /user/me with incorrect token');
-        $I->haveHttpHeader('Authorization', 'Bearer user11');
+        $I->haveHttpHeader('Authorization', 'Bearer invalidToken');
         $I->sendGET('/user/me');
         $I->seeResponseCodeIs(401);
     }
@@ -37,7 +37,7 @@ class UserCest extends BaseCest
     public function test4(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated POST request to /user/me');
-        $I->haveHttpHeader('Authorization', 'Bearer user11');
+        $I->haveHttpHeader('Authorization', 'Bearer invalidToken');
         $I->sendPOST('/user/me');
         $I->seeResponseCodeIs(401);
     }
@@ -53,7 +53,7 @@ class UserCest extends BaseCest
     public function test6(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated DELETE request to /user/me');
-        $I->haveHttpHeader('Authorization', 'Bearer user11');
+        $I->haveHttpHeader('Authorization', 'Bearer invalidToken');
         $I->sendDELETE('/user/me');
         $I->seeResponseCodeIs(401);
     }
@@ -69,7 +69,7 @@ class UserCest extends BaseCest
     public function test8(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated PATCH request to /user/me');
-        $I->haveHttpHeader('Authorization', 'Bearer user11');
+        $I->haveHttpHeader('Authorization', 'Bearer invalidToken');
         $I->sendPATCH('/user/me');
         $I->seeResponseCodeIs(401);
     }
@@ -85,7 +85,7 @@ class UserCest extends BaseCest
     public function test10(ApiTester $I)
     {
         $I->wantTo('check response when making unauthenticated OPTIONS request to /user/me');
-        $I->haveHttpHeader('Authorization', 'Bearer user1');
+        $I->haveHttpHeader('Authorization', 'Bearer invalidToken');
         $I->sendOPTIONS('/user/me');
         $I->seeResponseCodeIs(200);
     }

--- a/application/tests/api/fixtures/data/User.php
+++ b/application/tests/api/fixtures/data/User.php
@@ -15,6 +15,7 @@ return [
         'pw_expires' => null,
         'access_token' => Utils::getAccessTokenHash('user1'),
         'access_token_expiration' => Utils::getDatetime(time() + 1800),
+        'auth_type' => 'login',
     ],
     'user2' => [
         'id' => 2,
@@ -30,6 +31,7 @@ return [
         'pw_expires' => null,
         'access_token' => Utils::getAccessTokenHash('user2'),
         'access_token_expiration' => Utils::getDatetime(time() + 1800),
+        'auth_type' => 'login',
     ],
     'user3' => [
         'id' => 3,
@@ -45,6 +47,7 @@ return [
         'pw_expires' => null,
         'access_token' => Utils::getAccessTokenHash('user3'),
         'access_token_expiration' => Utils::getDatetime(time() + 1800),
+        'auth_type' => 'login',
     ],
     'user4' => [
         'id' => 4,
@@ -59,4 +62,20 @@ return [
         'pw_last_changed' => null,
         'pw_expires' => null,
     ],
+    'user5' => [
+        'id' => 5,
+        'uid' => '55555555555555555555555555555555',
+        'employee_id' => '5',
+        'first_name' => 'User',
+        'last_name' => 'Five',
+        'idp_username' => 'user_five',
+        'email' => 'user_five@organization.org',
+        'created' => '2016-02-29 11:58:00',
+        'last_login' => null,
+        'pw_last_changed' => null,
+        'pw_expires' => null,
+        'access_token' => Utils::getAccessTokenHash('user5'),
+        'access_token_expiration' => Utils::getDatetime(time() + 1800),
+        'auth_type' => 'reset',
+    ]
 ];


### PR DESCRIPTION
MethodController and MfaController now disallow all actions if the auth scope (auth_type) is not a full login, returning a http 403 response.

Updated api tests accordingly, and added new tests to confirm 403 response.