### PR TITLE
Use broker container for passwordStore tests

### DIFF
--- a/application/common/config/test.php
+++ b/application/common/config/test.php
@@ -59,8 +59,5 @@ return [
             'class' => 'tests\mock\phone\Component',
             'codeLength' => 4,
         ],
-        'passwordStore' => [
-            'class' => 'tests\mock\passwordstore\Component',
-        ],
     ],
 ];

--- a/application/tests/api/PasswordCest.php
+++ b/application/tests/api/PasswordCest.php
@@ -1,5 +1,8 @@
 <?php
 
+require_once "BaseCest.php";
+
+use common\helpers\Utils;
 
 class PasswordCest extends BaseCest
 {
@@ -51,7 +54,7 @@ class PasswordCest extends BaseCest
     {
         $I->wantTo('check response when making authenticated PUT request to update the password');
         $I->haveHttpHeader('Authorization', 'Bearer user1');
-        $I->sendPUT('/password',['password' => 'newPassword33!']);
+        $I->sendPUT('/password',['password' => Utils::generateRandomString() . '!12']);
         $I->seeResponseCodeIs(200);
     }
 
@@ -135,7 +138,7 @@ class PasswordCest extends BaseCest
     {
         $I->wantTo('check response when changing the password (PUT request) to something that has zxcvbn score of 2');
         $I->haveHttpHeader('Authorization', 'Bearer user1');
-        $I->sendPUT('/password',['password' => 'Hellow0rld1!']);
+        $I->sendPUT('/password',['password' => Utils::generateRandomString() . '!12']);
         $I->seeResponseCodeIs(200);
     }
 
@@ -143,7 +146,7 @@ class PasswordCest extends BaseCest
     {
         $I->wantTo('check response when changing the password (PUT request) to something that has zxcvbn score of 3');
         $I->haveHttpHeader('Authorization', 'Bearer user1');
-        $I->sendPUT('/password',['password' => 'Helloworld1010f!']);
+        $I->sendPUT('/password',['password' => Utils::generateRandomString() . '!12']);
         $I->seeResponseCodeIs(200);
     }
 

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -70,6 +70,7 @@ broker:
         PASSWORD_PROFILE_URL: https://example.com/#/profile
         SUPPORT_EMAIL: support@example.com
         EMAIL_SIGNATURE: Dummy Signature for Tests
+        EMAILER_CLASS: \Sil\SilIdBroker\Behat\Context\fakes\FakeEmailer
     command: whenavail brokerDb 3306 60 ./run-broker.sh
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,6 +161,7 @@ services:
             EMAIL_SERVICE_assertValidIp: "false"
             EMAIL_SERVICE_baseUrl: fake
             EMAIL_SERVICE_validIpRanges: 10.0.0.0/128
+            EMAILER_CLASS: \Sil\SilIdBroker\Behat\Context\fakes\FakeEmailer
             IDP_NAME: idp1
             MYSQL_HOST: brokerDb
             MYSQL_DATABASE: app


### PR DESCRIPTION
Change `passwordStore` component from a test double to the real ID Broker `passwordStore` component, and point it at the broker test container, as previously defined in `common/config/main.php`

Also changed the test passwords to random strings so that retesting with residual data in the database doesn't cause a password reuse exception.