### PR TITLE
Add configuration for debugging

### DIFF
--- a/application/run.sh
+++ b/application/run.sh
@@ -13,5 +13,10 @@ fi
 # Run database migrations
 runny /data/yii migrate --interactive=0
 
+if [[ $APP_ENV == "dev" ]]; then
+    export XDEBUG_CONFIG="remote_enable=1 remote_host="$REMOTE_DEBUG_IP
+    apt-get install php-xdebug
+fi
+
 # Run apache in foreground
 apache2ctl -D FOREGROUND

--- a/local.env.dist
+++ b/local.env.dist
@@ -43,3 +43,5 @@ AUTH_SAML_spPrivateKey=
 AUTH_SAML_entityId=idp-pw-api.local
 AUTH_SAML_ssoUrl=
 AUTH_SAML_sloUrl=
+APP_ENV=prod
+REMOTE_DEBUG_IP=


### PR DESCRIPTION
Added configuration for "remote" debugging while running in a Docker container. 

To set up debugging, do the following:

1. Add physical machine's IP address (or VM if running on macOS or Windows) into `REMOTE_DEBUG_IP` in `local.env` and set `APP_ENV` to `dev`.
2. In PHPStorm go to: Preferences > Languages & Frameworks > PHP > Debug > DBGp Proxy and set Host to the same IP address, and port to 9000.
3. Start PHPStorm listening by clicking the "listen" button on the toolbar. 
![image](https://user-images.githubusercontent.com/3172830/47380437-7ab22300-d6cb-11e8-8a6a-c00fa50fcd05.png)
