### PR TITLE
Create empty local.php if it doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,13 @@
 start: api
 
-test:
-	make testunit && make testapi && make testbehat
+test: testunit testapi
 
 testunit: composer emailcron rmTestDb upTestDb broker ldapload yiimigratetestDb
-	docker-compose run emailcron whenavail emaildb 3306 100 ./yii migrate --interactive=0
-	docker-compose run --rm cli bash -c 'MYSQL_HOST=testDb MYSQL_DATABASE=test ./vendor/bin/codecept run unit'
+	docker-compose run --rm unittest
 
 # Run testunit first at least once. Otherwise, this will have 5 test failures.
 testapi: upTestDb broker yiimigratetestDb
-	docker-compose up -d zxcvbn
 	docker-compose run --rm apitest
-
-testbehat:
-	docker-compose run --rm cli bash -c './vendor/bin/behat --config=tests/features/behat.yml --strict'
 
 api: upDb broker composer yiimigrate
 	docker-compose up -d api zxcvbn cron phpmyadmin

--- a/application/common/config/local.php.dist
+++ b/application/common/config/local.php.dist
@@ -1,0 +1,32 @@
+<?php
+
+use Sil\PhpEnv\Env;
+
+$zxcvbnApiBaseUrl = Env::get('ZXCVBN_API_BASEURL', 'http://zxcvbn:3000');
+
+return [
+    'params' => [
+        'accessTokenHashKey' => 'KEY4TESTING',
+        'password' => [
+            'minLength' => [
+                'value' => 10,
+                'phpRegex' => '/.{10,}/',
+                'jsRegex' => '.{10,}',
+                'enabled' => true
+            ],
+            'zxcvbn' => [
+                'minScore' => 2,
+                'enabled' => true,
+                'apiBaseUrl' => $zxcvbnApiBaseUrl,
+            ]
+        ],
+    ],
+    'components' => [
+        'mailer' => [
+            'useFileTransport' => true,
+            'transport' => [
+                'host' => null,
+            ],
+        ],
+    ],
+];

--- a/application/run.sh
+++ b/application/run.sh
@@ -10,6 +10,11 @@ else
     sleep 10
 fi
 
+# Create common/config/local.php if doesn't exist
+if [ ! -f /data/common/config/local.php ]; then
+    echo "<?php return [];" > /data/common/config/local.php
+fi
+
 # Run database migrations
 runny /data/yii migrate --interactive=0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
             - "8000:80"
         depends_on:
             - testDb
+            - zxcvbn
         env_file:
             - ./common.env
             - ./local.env
@@ -83,6 +84,25 @@ services:
             MYSQL_DATABASE: test
             APP_ENV: test
         command: ["/data/run-tests-api.sh"]
+
+    unittest:
+        build: ./
+        volumes_from:
+        - data
+        volumes:
+        - ./dockerbuild/dev-ldap.conf:/etc/ldap/ldap.conf
+        ports:
+        - "8000:80"
+        depends_on:
+        - testDb
+        env_file:
+        - ./common.env
+        - ./local.env
+        environment:
+            MYSQL_HOST: testDb
+            MYSQL_DATABASE: test
+            APP_ENV: test
+        command: ["/data/run-tests.sh"]
 
     cli:
         image: silintl/php7:latest


### PR DESCRIPTION
Although no information is needed in local.php, the file is expected to exist. The run.sh script will now create an empty file if it doesn't already exist by some other means (e.g. Docker volume).

Also cleaned up local (dev) test to more closely match the Codeship test.