### PR TITLE
Send CORS headers on all responses

### DIFF
--- a/application/frontend/components/BaseRestController.php
+++ b/application/frontend/components/BaseRestController.php
@@ -27,19 +27,6 @@ class BaseRestController extends Controller
                 ],
                 'except' => ['options'],
             ],
-            'corsFilter' => [
-                'class' => Cors::class,
-                'actions' => ['index', 'view', 'create', 'update', 'delete', 'options'],
-                'cors' => [
-                    'Origin' => [\Yii::$app->params['uiCorsOrigin']],
-                    'Access-Control-Request-Method' => [
-                        'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'
-                    ],
-                    'Access-Control-Request-Headers' => ['*'],
-                    'Access-Control-Allow-Credentials' => true,
-                    'Access-Control-Max-Age' => 86400,
-                ]
-            ],
             'access' => [
                 'class' => AccessControl::class,
                 'rules' => [

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -47,7 +47,10 @@ return [
                 $response = $event->sender;
                 $response->headers->set('Access-Control-Allow-Origin', \Yii::$app->params['uiCorsOrigin']);
                 $response->headers->set('Access-Control-Allow-Credentials', 'true');
-                $response->headers->set('Access-Control-Request-Method', 'GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS');
+                $response->headers->set(
+                    'Access-Control-Request-Method', 
+                    'GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS'
+                );
                 $response->headers->set('Access-Control-Request-Headers', '*');
                 $response->headers->set('Access-Control-Max-Age', 86400);
             },

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -40,6 +40,18 @@ return [
                 'secure' => $frontCookieSecure,
             ],
         ],
+        'response' => [
+            'class' => 'yii\web\Response',
+            'on beforeSend' => function ($event) {
+                /** @var yii\web\Response $response */
+                $response = $event->sender;
+                $response->headers->set('Access-Control-Allow-Origin', \Yii::$app->params['uiCorsOrigin']);
+                $response->headers->set('Access-Control-Allow-Credentials', 'true');
+                $response->headers->set('Access-Control-Request-Method', 'GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS');
+                $response->headers->set('Access-Control-Request-Headers', '*');
+                $response->headers->set('Access-Control-Max-Age', 86400);
+            },
+        ],
         'log' => [
 
         ],


### PR DESCRIPTION
The Yii CORS filter didn't work on error responses. This PR replaces the CORS filter with unconditionally adding the CORS headers to all responses.