### PR TITLE
Change password reuse error

### DIFF
--- a/application/common/components/passwordStore/IdBroker.php
+++ b/application/common/components/passwordStore/IdBroker.php
@@ -95,7 +95,7 @@ class IdBroker extends Component implements PasswordStoreInterface
             );
             return $meta;
         } catch (ServiceException $e) {
-            if ($e->httpStatusCode === 422) {
+            if ($e->httpStatusCode === 409) {
                 throw new PasswordReuseException();
             }
             throw $e;

--- a/application/common/models/Password.php
+++ b/application/common/models/Password.php
@@ -7,6 +7,7 @@ use common\components\passwordStore\PasswordReuseException;
 use yii\base\Model;
 use yii\helpers\Json;
 use yii\web\BadRequestHttpException;
+use yii\web\ConflictHttpException;
 use yii\web\ServerErrorHttpException;
 
 class Password extends Model
@@ -222,7 +223,7 @@ class Password extends Model
              */
             if ($e instanceof  PasswordReuseException) {
                 \Yii::warning($log);
-                throw new BadRequestHttpException(
+                throw new ConflictHttpException(
                     \Yii::t(
                         'app',
                         'Unable to update password. ' .


### PR DESCRIPTION
In order to present the user with an opportunity to enter a new password, the HTTP status code for password reuse should be 409 instead of 400.