### PR TITLE
purge old, expired resets by cron job

### DIFF
--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -236,8 +236,9 @@ return [
         'emailServiceStatus' => $emailServiceConfig,
         'emailVerification' => $emailServiceConfig,
         'reset' => [
-            'lifetimeSeconds' => 3600, // 1 hour
-            'disableDuration' => 900, // 15 minutes
+            'lifetimeSeconds' => 3600,  // 1 hour
+            'gracePeriod' => '-1 week', // time between expiration and deletion
+            'disableDuration' => 900,   // 15 minutes
             'codeLength' => $codeLength,
             'maxAttempts' => 10,
         ],

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -237,7 +237,7 @@ return [
         'emailVerification' => $emailServiceConfig,
         'reset' => [
             'lifetimeSeconds' => 3600,  // 1 hour
-            'gracePeriod' => '-1 week', // time between expiration and deletion
+            'gracePeriod' => '-1 week', // time between expiration and deletion, relative to now (time of execution)
             'disableDuration' => 900,   // 15 minutes
             'codeLength' => $codeLength,
             'maxAttempts' => 10,

--- a/application/common/models/Reset.php
+++ b/application/common/models/Reset.php
@@ -659,6 +659,11 @@ class Reset extends ResetBase
          * Replace '+' with '-' just to be sure it's correctly defined
          */
         $resetGracePeriod = str_replace('+', '-', \Yii::$app->params['reset']['gracePeriod']);
+
+        /**
+         * @var string $removeExpireBefore   All records that expired before this date
+         * should be deleted. Calculated relative to now (time of execution).
+         */
         $removeExpireBefore = Utils::getDatetime(strtotime($resetGracePeriod));
         $resets = self::find()->andWhere(['<', 'expires', $removeExpireBefore])->all();
 

--- a/application/common/models/Reset.php
+++ b/application/common/models/Reset.php
@@ -87,11 +87,6 @@ class Reset extends ResetBase
      */
     public static function findOrCreate($user)
     {
-        /*
-         * Clean up expired resets
-         */
-        self::deleteExpired();
-
         $log = [
             'action' => 'findOrCreate reset',
             'user_id' => $user->id,
@@ -623,33 +618,6 @@ class Reset extends ResetBase
                 'user' => $this->user->email,                
             ]);
             throw new ServerErrorHttpException(\Yii::t('app', $errorPrefix));
-        }
-    }
-
-    /**
-     * Delete all expired Reset records
-     */
-    public static function deleteExpired()
-    {
-        try {
-            $deleted = self::deleteAll(
-                ['<', 'expires', Utils::getDatetime()]
-            );
-
-            if ($deleted > 0) {
-                \Yii::warning([
-                    'action' => 'delete expired resets',
-                    'status' => 'success',
-                    'deleted count' => $deleted,
-                ]);
-            }
-        } catch (\Exception $e) {
-            \Yii::error([
-                'action' => 'delete expired resets',
-                'status' => 'error',
-                'error' => $e->getMessage(),
-                'code' => $e->getCode(),
-            ]);
         }
     }
 

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -4,6 +4,7 @@ namespace console\controllers;
 use Sil\Idp\IdBroker\Client\IdBrokerClient;
 use common\models\EmailQueue;
 use common\models\Method;
+use common\models\Reset;
 use yii\console\Controller;
 
 class CronController extends Controller
@@ -127,5 +128,21 @@ class CronController extends Controller
         echo (string)round($endTime - $startTime, 3) . ' sec, '
             . (string)round($msecPerRecord, 0) . ' ms per record' . PHP_EOL;
         echo 'finished cron/move-method-data' . PHP_EOL;
+    }
+
+    public function actionRemoveOldRecords()
+    {
+        \Yii::warning([
+            'action' => 'delete old reset records',
+            'status' => 'starting',
+        ]);
+
+        $numDeleted = Reset::purge();
+
+        \Yii::warning([
+            'action' => 'delete old reset records',
+            'status' => 'complete',
+            'count' => $numDeleted,
+        ]);
     }
 }

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -142,10 +142,11 @@ class ResetController extends BaseRestController
          */
         $reset = Reset::findOrCreate($user);
 
-        /*
-         * Send reset notification
-         */
-        $reset->send();
+        if ($reset->isExpired()) {
+            $reset->restart();
+        } else {
+            $reset->send();
+        }
 
         if ($user->hide === 'yes') {
             throw new NotFoundHttpException(

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -128,12 +128,6 @@ class ResetController extends BaseRestController
             );
         }
 
-
-        /*
-         * Clear out expired resets
-         */
-        Reset::deleteExpired();
-
         /*
          * Calling getPasswordMeta simply to test for a locked account.
          */

--- a/dockerbuild/idp-cron
+++ b/dockerbuild/idp-cron
@@ -1,4 +1,4 @@
 # m h dom mon dow user	command
 * * * * * root /data/yii cron/send-queued-email
-* * * * * root /data/yii cron/move-method-data
-
+*/10 * * * * root /data/yii cron/move-method-data
+10 */6 * * * root /data/yii cron/remove-old-records


### PR DESCRIPTION
Rather than a "lazy delete" of old records, we now use cron to purge old records. Also, there is now a concept of a "grace period". After a reset has expired, we'll keep it for a little while in case the user clicks on an old link. (See PR #141)