### PR TITLE
destroy auth token on password change

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -607,7 +607,7 @@ class User extends UserBase implements IdentityInterface
         $this->access_token_expiration = null;
         $this->auth_type = null;
 
-        if (!$this->save()) {
+        if (! $this->save()) {
             \Yii::error([
                 'action' => 'destroy access token',
                 'status' => 'error',

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -10,6 +10,7 @@ use common\components\personnel\PersonnelInterface;
 use common\components\personnel\PersonnelUser;
 use common\helpers\Utils;
 use yii\helpers\ArrayHelper;
+use yii\helpers\Json;
 use yii\web\IdentityInterface;
 use yii\web\ServerErrorHttpException;
 
@@ -591,6 +592,24 @@ class User extends UserBase implements IdentityInterface
         }
 
         return $accessToken;
+    }
+
+    /**
+     *
+     */
+    public function destroyAccessToken(): void
+    {
+        $this->access_token = null;
+        $this->access_token_expiration = null;
+        $this->auth_type = null;
+
+        if (!$this->save()) {
+            \Yii::error([
+                'action' => 'destroy access token',
+                'status' => 'error',
+                'error' => Json::encode($this->getFirstErrors()),
+            ]);
+        }
     }
 
     /**

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -561,6 +561,10 @@ class User extends UserBase implements IdentityInterface
             ],
             $this->id
         );
+
+        if ($this->auth_type == self::AUTH_TYPE_LOGIN) {
+            $this->destroyAccessToken();
+        }
     }
 
     /**

--- a/application/frontend/controllers/AuthController.php
+++ b/application/frontend/controllers/AuthController.php
@@ -12,7 +12,6 @@ use Sil\Idp\IdBroker\Client\ServiceException;
 use yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
-use yii\helpers\Json;
 use yii\web\BadRequestHttpException;
 use yii\web\ServerErrorHttpException;
 
@@ -133,15 +132,7 @@ class AuthController extends BaseRestController
             $accessTokenHash = Utils::getAccessTokenHash($accessToken);
             $user = User::findOne(['access_token' => $accessTokenHash]);
             if ($user != null) {
-                $user->access_token = null;
-                $user->access_token_expiration = null;
-                if ( ! $user->save()) {
-                    \Yii::error([
-                        'action' => 'user logout',
-                        'status' => 'error',
-                        'error' => Json::encode($user->getFirstErrors()),
-                    ]);
-                }
+                $user->destroyAccessToken();
 
                 /** @var AuthUser $authUser */
                 $authUser = $user->getAuthUser();


### PR DESCRIPTION
If the `auth_type` is `LOGIN` (password), and the user sets a new password, destroy the `access_token` to force a new login.