### PR TITLE
Create isLocked method on passwordStore interface

### DIFF
--- a/application/common/components/passwordStore/Google.php
+++ b/application/common/components/passwordStore/Google.php
@@ -231,4 +231,9 @@ class Google extends Component implements PasswordStoreInterface
          * simply return an "empty" UserPasswordMeta object.  */
         return UserPasswordMeta::create('', '');
     }
+
+    public function isLocked(string $employeeId): bool
+    {
+        return false;
+    }
 }

--- a/application/common/components/passwordStore/IdBroker.php
+++ b/application/common/components/passwordStore/IdBroker.php
@@ -9,26 +9,6 @@ use yii\base\Component;
 class IdBroker extends Component implements PasswordStoreInterface
 {
     /**
-     * @var string base Url for the API
-     */
-    public $baseUrl;
-
-    /**
-     * @var string access Token for the API
-     */
-    public $accessToken;
-
-    /**
-     * @var boolean
-     */
-    public $assertValidBrokerIp = true;
-
-    /**
-     * @var IPBlock[]
-     */
-    public $validIpRanges = [];
-
-    /**
      * @var IdBrokerClient $client
      */
     private $client;
@@ -43,12 +23,13 @@ class IdBroker extends Component implements PasswordStoreInterface
     public function init()
     {
         parent::init();
+        $config = \Yii::$app->params['idBrokerConfig'];
         $this->client = new IdBrokerClient(
-            $this->baseUrl,
-            $this->accessToken,
+            $config['baseUrl'],
+            $config['accessToken'],
             [
-                IdBrokerClient::TRUSTED_IPS_CONFIG => $this->validIpRanges,
-                IdBrokerClient::ASSERT_VALID_BROKER_IP_CONFIG => $this->assertValidBrokerIp,
+                IdBrokerClient::TRUSTED_IPS_CONFIG => $config['validIpRanges'] ?? [],
+                IdBrokerClient::ASSERT_VALID_BROKER_IP_CONFIG => $config['assertValidBrokerIp'] ?? true,
             ]
         );
     }
@@ -106,7 +87,7 @@ class IdBroker extends Component implements PasswordStoreInterface
      * This getter method facilitates test by allowing a fake client to be substituted.
      * @return IdBrokerClient
      */
-    public function getClient(): IdBrokerClient
+    public function getClient()
     {
         return $this->client;
     }

--- a/application/common/components/passwordStore/IdBroker.php
+++ b/application/common/components/passwordStore/IdBroker.php
@@ -87,7 +87,7 @@ class IdBroker extends Component implements PasswordStoreInterface
         $this->getUser($employeeId);
 
         try {
-            $update = $this->client->setPassword($employeeId, $password);
+            $update = $this->getClient()->setPassword($employeeId, $password);
         } catch (ServiceException $e) {
             if ($e->httpStatusCode === 409) {
                 throw new PasswordReuseException();
@@ -100,6 +100,15 @@ class IdBroker extends Component implements PasswordStoreInterface
             $update['password']['created_utc'] ?? null
         );
         return $meta;
+    }
+
+    /**
+     * This getter method facilitates test by allowing a fake client to be substituted.
+     * @return IdBrokerClient
+     */
+    public function getClient(): IdBrokerClient
+    {
+        return $this->client;
     }
 
     /**
@@ -128,7 +137,7 @@ class IdBroker extends Component implements PasswordStoreInterface
      */
     private function getUser($employeeId)
     {
-        $user = $this->client->getUser($employeeId);
+        $user = $this->getClient()->getUser($employeeId);
 
         if ($user === null) {
             throw new UserNotFoundException();

--- a/application/common/components/passwordStore/IdBroker.php
+++ b/application/common/components/passwordStore/IdBroker.php
@@ -110,4 +110,25 @@ class IdBroker extends Component implements PasswordStoreInterface
             IdBrokerClient::ASSERT_VALID_BROKER_IP_CONFIG => $this->assertValidBrokerIp,
         ]);
     }
+
+    /**
+     * @param string $employeeId
+     * @return bool
+     * @throws \Exception
+     * @throws \InvalidArgumentException
+     * @throws ServiceException
+     * @throws UserNotFoundException
+     */
+    public function isLocked(string $employeeId): bool
+    {
+        $client = $this->getClient();
+
+        $user = $client->getUser($employeeId);
+
+        if ($user === null) {
+            throw new UserNotFoundException();
+        }
+
+        return ($user['locked'] == 'yes');
+    }
 }

--- a/application/common/components/passwordStore/IdBroker.php
+++ b/application/common/components/passwordStore/IdBroker.php
@@ -34,6 +34,8 @@ class IdBroker extends Component implements PasswordStoreInterface
      * Get metadata about user's password including last_changed_date and expires_date
      * @param string $employeeId
      * @return UserPasswordMeta
+     * @throws \Exception if a configured IP falls outside the approved range
+     * @throws \InvalidArgumentException if configuration is incomplete
      * @throws ServiceException
      * @throws UserNotFoundException
      * @throws AccountLockedException
@@ -64,6 +66,8 @@ class IdBroker extends Component implements PasswordStoreInterface
      * @param string $employeeId
      * @param string $password
      * @return UserPasswordMeta
+     * @throws \Exception if a configured IP falls outside the approved range
+     * @throws \InvalidArgumentException if configuration is incomplete
      * @throws UserNotFoundException
      * @throws AccountLockedException
      * @throws ServiceException
@@ -101,7 +105,8 @@ class IdBroker extends Component implements PasswordStoreInterface
 
     /**
      * @return IdBrokerClient
-     * @throws \Exception
+     * @throws \Exception if a configured IP falls outside the approved range
+     * @throws \InvalidArgumentException if configuration is incomplete
      */
     public function getClient()
     {
@@ -114,8 +119,8 @@ class IdBroker extends Component implements PasswordStoreInterface
     /**
      * @param string $employeeId
      * @return bool
-     * @throws \Exception
-     * @throws \InvalidArgumentException
+     * @throws \Exception if a configured IP falls outside the approved range
+     * @throws \InvalidArgumentException if configuration is incomplete
      * @throws ServiceException
      * @throws UserNotFoundException
      */

--- a/application/common/components/passwordStore/Ldap.php
+++ b/application/common/components/passwordStore/Ldap.php
@@ -365,4 +365,16 @@ class Ldap extends Component implements PasswordStoreInterface
 
         return $user;
     }
+
+    public function isLocked(string $employeeId): bool
+    {
+        $user = $this->findUser($employeeId);
+
+        try {
+            $this->assertUserNotDisabled($user);
+        } catch (AccountLockedException $e) {
+            return true;
+        }
+        return false;
+    }
 }

--- a/application/common/components/passwordStore/Multiple.php
+++ b/application/common/components/passwordStore/Multiple.php
@@ -79,8 +79,8 @@ class Multiple extends Component implements PasswordStoreInterface
      *
      * @param string $employeeId The Employee ID of the user.
      * @return UserPasswordMeta
-     * @throw UserNotFoundException
-     * @throw AccountLockedException
+     * @throws UserNotFoundException
+     * @throws AccountLockedException
      */
     public function getMeta($employeeId): UserPasswordMeta
     {
@@ -133,13 +133,18 @@ class Multiple extends Component implements PasswordStoreInterface
         return $responses[0];
     }
 
+    /**
+     * @param string $employeeId
+     * @return bool
+     * @throws UserNotFoundException
+     */
     public function isLocked(string $employeeId): bool
     {
-        try {
-            $this->getMeta($employeeId);
-        } catch (AccountLockedException $e) {
-            return false;
+        foreach ($this->passwordStores as $passwordStore) {
+            if ($passwordStore->isLocked($employeeId)) {
+                return true;
+            }
         }
-        return true;
+        return false;
     }
 }

--- a/application/common/components/passwordStore/Multiple.php
+++ b/application/common/components/passwordStore/Multiple.php
@@ -132,4 +132,14 @@ class Multiple extends Component implements PasswordStoreInterface
         }
         return $responses[0];
     }
+
+    public function isLocked(string $employeeId): bool
+    {
+        try {
+            $this->getMeta($employeeId);
+        } catch (AccountLockedException $e) {
+            return false;
+        }
+        return true;
+    }
 }

--- a/application/common/components/passwordStore/PasswordStoreInterface.php
+++ b/application/common/components/passwordStore/PasswordStoreInterface.php
@@ -26,4 +26,12 @@ interface PasswordStoreInterface
      * @throws \common\components\passwordStore\AccountLockedException
      */
     public function set($employeeId, $password);
+
+    /**
+     * Is user account locked?
+     * @param string $employeeId
+     * @return bool
+     * @throws \common\components\passwordStore\UserNotFoundException
+     */
+    public function isLocked(string $employeeId): bool;
 }

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -215,11 +215,7 @@ return [
             ['class' => 'common\components\auth\Saml'],
             Env::getArrayFromPrefix('AUTH_SAML_')
         ),
-        'passwordStore' => ArrayHelper::merge(
-            ['class' => 'common\components\passwordStore\IdBroker'],
-            Env::getArrayFromPrefix('ID_BROKER_'),
-            ['validIpRanges' => Env::getArray('ID_BROKER_validIpRanges')]
-        ),
+        'passwordStore' => ['class' => 'common\components\passwordStore\IdBroker'],
     ],
     'params' => [
         'idpName' => $idpName,

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -58,8 +58,8 @@ if ( ! $emailServiceConfig['useEmailService']) {
 }
 $emailServiceConfig['validIpRanges'] = Env::getArray('EMAIL_SERVICE_validIpRanges');
 
-$mfaConfig = Env::getArrayFromPrefix('ID_BROKER_');
-$mfaConfig['validIpRanges'] = Env::getArray('ID_BROKER_validIpRanges');
+$idBrokerConfig = Env::getArrayFromPrefix('ID_BROKER_');
+$idBrokerConfig['validIpRanges'] = Env::getArray('ID_BROKER_validIpRanges');
 
 return [
     'id' => 'app-common',
@@ -293,6 +293,6 @@ return [
             'url' => $supportUrl,
             'feedbackUrl' => $supportFeedback,
         ],
-        'mfa' => $mfaConfig,
+        'idBrokerConfig' => $idBrokerConfig,
     ],
 ];

--- a/application/common/models/Method.php
+++ b/application/common/models/Method.php
@@ -26,7 +26,7 @@ class Method extends MethodBase
     public function init()
     {
         parent::init();
-        $config = \Yii::$app->params['mfa'];
+        $config = \Yii::$app->params['idBrokerConfig'];
         $this->idBrokerClient = new IdBrokerClient(
             $config['baseUrl'],
             $config['accessToken'],

--- a/application/common/models/Password.php
+++ b/application/common/models/Password.php
@@ -1,11 +1,9 @@
 <?php
 namespace common\models;
 
-use common\helpers\Utils;
 use common\helpers\ZxcvbnPasswordValidator;
 use common\components\passwordStore\PasswordReuseException;
 use yii\base\Model;
-use yii\helpers\Json;
 use yii\web\BadRequestHttpException;
 use yii\web\ConflictHttpException;
 use yii\web\ServerErrorHttpException;

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -504,7 +504,7 @@ class User extends UserBase implements IdentityInterface
 
     /**
      * Is user account locked?
-     * @return true
+     * @return bool
      * @throws \Exception
      */
     public function isLocked(): bool

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -503,6 +503,19 @@ class User extends UserBase implements IdentityInterface
     }
 
     /**
+     * Is user account locked?
+     * @return true
+     * @throws \Exception
+     */
+    public function isLocked(): bool
+    {
+        /** @var PasswordStoreInterface $passwordStore */
+        $passwordStore = \Yii::$app->passwordStore;
+
+        return $passwordStore->isLocked($this->employee_id);
+    }
+
+    /**
      * Retrieve password metadata from the password store interface, and update the local
      * database with the new data. Returns an array containing the received properties,
      * or null in case of error or empty data.

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -493,12 +493,8 @@ class User extends UserBase implements IdentityInterface
         /** @var PasswordStoreInterface $passwordStore */
         $passwordStore = \Yii::$app->passwordStore;
 
-        /*
-         * If password metadata is missing, fetch from passwordStore and update
-         */
         /** @var UserPasswordMeta $pwMeta */
         $pwMeta = $passwordStore->getMeta($this->employee_id);
-
 
         return [
             'last_changed' => $pwMeta->passwordLastChangeDate,

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -50,7 +50,7 @@ class CronController extends Controller
      */
     protected function getIdBrokerClient()
     {
-        $config = \Yii::$app->params['mfa'];
+        $config = \Yii::$app->params['idBrokerConfig'];
         return new IdBrokerClient(
             $config['baseUrl'],
             $config['accessToken'],

--- a/application/frontend/controllers/MethodController.php
+++ b/application/frontend/controllers/MethodController.php
@@ -23,7 +23,7 @@ class MethodController extends BaseRestController
     public function init()
     {
         parent::init();
-        $config = \Yii::$app->params['mfa'];
+        $config = \Yii::$app->params['idBrokerConfig'];
         $this->idBrokerClient = new IdBrokerClient(
             $config['baseUrl'],
             $config['accessToken'],

--- a/application/frontend/controllers/MfaController.php
+++ b/application/frontend/controllers/MfaController.php
@@ -47,7 +47,7 @@ class MfaController extends BaseRestController
     public function init()
     {
         parent::init();
-        $config = \Yii::$app->params['mfa'];
+        $config = \Yii::$app->params['idBrokerConfig'];
         $this->idBrokerClient = new IdBrokerClient(
             $config['baseUrl'],
             $config['accessToken'],

--- a/application/frontend/controllers/ResetController.php
+++ b/application/frontend/controllers/ResetController.php
@@ -128,12 +128,7 @@ class ResetController extends BaseRestController
             );
         }
 
-        /*
-         * Calling getPasswordMeta simply to test for a locked account.
-         */
-        try {
-            $user->getPasswordMeta();
-        } catch (AccountLockedException $e) {
+        if ($user->isLocked()) {
             throw new NotFoundHttpException();
         }
 

--- a/application/tests/features/DummyPasswordStore.php
+++ b/application/tests/features/DummyPasswordStore.php
@@ -45,4 +45,12 @@ class DummyPasswordStore extends Component implements PasswordStoreInterface
         }
         return UserPasswordMeta::create($this->uniqueDate, $this->uniqueDate);
     }
+
+    public function isLocked(string $employeeId): bool
+    {
+        if ( ! $this->isOnline) {
+            throw new \Exception('Failed to check if employeeId ' . $employeeId . ' is locked');
+        }
+        return false;
+    }
 }

--- a/application/tests/mock/passwordstore/Component.php
+++ b/application/tests/mock/passwordstore/Component.php
@@ -59,4 +59,9 @@ class Component implements PasswordStoreInterface
             IdBrokerClient::ASSERT_VALID_BROKER_IP_CONFIG => false,
         ]);
     }
+
+    public function isLocked(string $employeeId): bool
+    {
+        return false;
+    }
 }

--- a/application/tests/mock/passwordstore/Component.php
+++ b/application/tests/mock/passwordstore/Component.php
@@ -53,8 +53,8 @@ class Component implements PasswordStoreInterface
      */
     public function getClient()
     {
-        $baseUrl = \Yii::$app->passwordStore->baseUrl;
-        $accessToken = \Yii::$app->passwordStore->accessToken;
+        $baseUrl = \Yii::$app->params['idBrokerConfig']['baseUrl'];
+        $accessToken = \Yii::$app->params['idBrokerConfig']['accessToken'];
         return new IdBrokerClient($baseUrl, $accessToken, [
             IdBrokerClient::ASSERT_VALID_BROKER_IP_CONFIG => false,
         ]);


### PR DESCRIPTION
In order to block a password reset for locked accounts, we need to have a method on `passwordStore` get the lock status. Previously, `getMeta()` was used for this, but a dedicated getter method is cleaner.