### PR TITLE
remove unnecessary password rules

### DIFF
--- a/application/common/config/local.php.dist
+++ b/application/common/config/local.php.dist
@@ -19,24 +19,6 @@ return [
                 'jsRegex' => '.{0,255}',
                 'enabled' => true
             ],
-            'minNum' => [
-                'value' => 2,
-                'phpRegex' => '/(\d.*){2,}/',
-                'jsRegex' => '(\d.*){2,}',
-                'enabled' => true
-            ],
-            'minUpper' => [
-                'value' => 1,
-                'phpRegex' => '/([A-Z].*){1,}/',
-                'jsRegex' => '([A-Z].*){1,}',
-                'enabled' => true
-            ],
-            'minSpecial' => [
-                'value' => 1,
-                'phpRegex' => '/([\W_].*){1,}/',
-                'jsRegex' => '([\W_].*){1,}',
-                'enabled' => true
-            ],
             'zxcvbn' => [
                 'minScore' => 2,
                 'enabled' => true,

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -54,9 +54,6 @@ $zxcvbnApiBaseUrl = Env::get('ZXCVBN_API_BASEURL');
 $passwordRules = Env::getArrayFromPrefix('PASSWORD_RULE_');
 $passwordRules['minLength'] = $passwordRules['minLength'] ?? null;
 $passwordRules['maxLength'] = $passwordRules['maxLength'] ?? null;
-$passwordRules['minNum'] = $passwordRules['minNum'] ?? null;
-$passwordRules['minUpper'] = $passwordRules['minUpper'] ?? null;
-$passwordRules['minSpecial'] = $passwordRules['minSpecial'] ?? null;
 $passwordRules['minScore'] = $passwordRules['minScore'] ?? null;
 
 return [
@@ -196,24 +193,6 @@ return [
                 'phpRegex' => '/^.{0,' . $passwordRules['maxLength'] . '}$/',
                 'jsRegex' => '.{0,' . $passwordRules['maxLength'] . '}',
                 'enabled' => $passwordRules['maxLength'] !== null
-            ],
-            'minNum' => [
-                'value' => $passwordRules['minNum'],
-                'phpRegex' => '/(\d.*){' . $passwordRules['minNum'] . ',}/',
-                'jsRegex' => '(\d.*){' . $passwordRules['minNum'] . ',}',
-                'enabled' => $passwordRules['minNum'] !== null
-            ],
-            'minUpper' => [
-                'value' => $passwordRules['minUpper'],
-                'phpRegex' => '/([A-Z].*){' . $passwordRules['minUpper'] . ',}/',
-                'jsRegex' => '([A-Z].*){' . $passwordRules['minUpper'] . ',}',
-                'enabled' => $passwordRules['minUpper'] !== null
-            ],
-            'minSpecial' => [
-                'value' => $passwordRules['minSpecial'],
-                'phpRegex' => '/([\W_].*){' . $passwordRules['minSpecial'] . ',}/',
-                'jsRegex' => '([\W_].*){' . $passwordRules['minSpecial'] . ',}',
-                'enabled' => $passwordRules['minSpecial'] !== null
             ],
             'zxcvbn' => [
                 'minScore' => $passwordRules['minScore'],

--- a/application/common/helpers/Utils.php
+++ b/application/common/helpers/Utils.php
@@ -197,7 +197,7 @@ class Utils
 
         $config['password'] = [];
         $passwordRuleFields = [
-            'minLength', 'maxLength', 'minNum', 'minUpper', 'minSpecial'
+            'minLength', 'maxLength'
         ];
 
         foreach ($passwordRuleFields as $rule) {

--- a/application/common/models/Password.php
+++ b/application/common/models/Password.php
@@ -55,36 +55,6 @@ class Password extends Model
                 'when' => function() { return $this->config['maxLength']['enabled']; }
             ],
             [
-                'password', 'match', 'pattern' => $this->config['minNum']['phpRegex'],
-                'skipOnError' => false,
-                'message' => \Yii::t(
-                    'app',
-                    'Your password must contain at least {minNum} numbers (code 120)',
-                    ['minNum' => $this->config['minNum']['value']]
-                ),
-                'when' => function() { return $this->config['minNum']['enabled']; }
-            ],
-            [
-                'password', 'match', 'pattern' => $this->config['minUpper']['phpRegex'],
-                'skipOnError' => false,
-                'message' => \Yii::t(
-                    'app',
-                    'Your password must contain at least {minUpper} upper case letters (code 130)',
-                    ['minUpper' => $this->config['minUpper']['value']]
-                ),
-                'when' => function() { return $this->config['minUpper']['enabled']; }
-            ],
-            [
-                'password', 'match', 'pattern' => $this->config['minSpecial']['phpRegex'],
-                'skipOnError' => false,
-                'message' => \Yii::t(
-                    'app',
-                    'Your password must contain at least {minSpecial} special characters (code 140)',
-                    ['minSpecial' => $this->config['minSpecial']['value']]
-                ),
-                'when' => function() { return $this->config['minSpecial']['enabled']; }
-            ],
-            [
                 'password', ZxcvbnPasswordValidator::class, 'minScore' => $this->config['zxcvbn']['minScore'],
                 'skipOnError' => true,
                 'message' => \Yii::t(

--- a/application/frontend/messages/fr/app.php
+++ b/application/frontend/messages/fr/app.php
@@ -50,15 +50,6 @@ return [
     'Your password exceeds the maximum length of {maxLength} (code 110)' =>
         'Votre mot de passe dépasse la longueur maximale de {maxLength} (code 110)',
 
-    'Your password must contain at least {minNum} numbers (code 120)' =>
-        'Votre mot de passe doit contenir au moins {minNum} chiffres (code 120)',
-
-    'Your password must contain at least {minUpper} upper case letters (code 130)' =>
-        'Votre mot de passe doit contenir au moins {minUpper} lettres majuscules (code 130)',
-
-    'Your password must contain at least {minSpecial} special characters (code 140)' =>
-        'Votre mot de passe doit contenir au moins {minSpecial} caractères spéciaux (code 140)',
-
     'Your password does not meet the minimum strength of {minScore} (code 150)' =>
         'Votre mot de passe ne répond pas à la force minimale de {minScore} (code 150)',
 

--- a/application/tests/api/PasswordCest.php
+++ b/application/tests/api/PasswordCest.php
@@ -110,18 +110,6 @@ class PasswordCest extends BaseCest
         }
     }
 
-    public function test13(ApiTester $I)
-    {
-        $I->wantTo('check response when changing the password (PUT request) to something that does not meet minNumber requirement');
-        $I->haveHttpHeader('Authorization', 'Bearer user1');
-        $I->sendPUT('/password',['password' => 'A!sdfasdfasdfasdf1']);
-        $I->seeResponseCodeIs(400);
-        $body = json_decode($I->grabResponse(), true);
-        if (substr_count($body['message'], 'code 120') <= 0) {
-            throw new \Exception('Expected error code not present in message', 1466798391);
-        }
-    }
-
     public function test15(ApiTester $I)
     {
         $I->wantTo('check response when changing the password (PUT request) to something that has zxcvbn score of 1');

--- a/application/tests/unit/common/helpers/UtilsTest.php
+++ b/application/tests/unit/common/helpers/UtilsTest.php
@@ -76,24 +76,6 @@ class UtilsTest extends Test
                     'jsRegex' => '.{0,255}',
                     'enabled' => true
                 ],
-                'minNum' => [
-                    'value' => 2,
-                    'phpRegex' => '/(\d.*){2,}/',
-                    'jsRegex' => '(\d.*){2,}',
-                    'enabled' => true
-                ],
-                'minUpper' => [
-                    'value' => 0,
-                    'phpRegex' => '/([A-Z].*){0,}/',
-                    'jsRegex' => '([A-Z].*){0,}',
-                    'enabled' => false
-                ],
-                'minSpecial' => [
-                    'value' => 0,
-                    'phpRegex' => '/([\W_].*){0,}/',
-                    'jsRegex' => '([\W_].*){0,}',
-                    'enabled' => false
-                ],
                 'zxcvbn' => [
                     'minScore' => 2,
                     'enabled' => true,

--- a/application/tests/unit/common/models/PasswordTest.php
+++ b/application/tests/unit/common/models/PasswordTest.php
@@ -61,26 +61,6 @@ class PasswordTest extends Test
                 'Failed validating test case: ' . $testCase['password']
             );
 
-            $minNumStatus = ! substr_count($validationErrorsString, 'code 120') > 0;
-            $this->assertEquals(
-                $testCase['minNum'],
-                $minNumStatus,
-                'Failed validating test case: ' . $testCase['password']
-            );
-
-            $minUpperStatus = ! substr_count($validationErrorsString, 'code 130') > 0;
-            $this->assertEquals(
-                $testCase['minUpper'],
-                $minUpperStatus, 'Failed validating test case: ' . $testCase['password']
-            );
-
-            $minSpecialStatus = ! substr_count($validationErrorsString, 'code 140') > 0;
-            $this->assertEquals(
-                $testCase['minSpecial'],
-                $minSpecialStatus,
-                'Failed validating test case: ' . $testCase['password']
-            );
-
             /*
              * Zxcvbn validation is skipped if any other validation errors occur, so only assert
              * failure if other tests pass and this should fail
@@ -134,9 +114,6 @@ class PasswordTest extends Test
                 'zxcvbnPass' => false,
                 'minLength' => false,
                 'maxLength' => true,
-                'minNum' => true,
-                'minUpper' => false,
-                'minSpecial' => false,
                 'overall' => false,
                 'nonZxcvbnPass' => false,
             ],
@@ -146,9 +123,6 @@ class PasswordTest extends Test
                 'zxcvbnPass' => true,
                 'minLength' => true,
                 'maxLength' => true,
-                'minNum' => true,
-                'minUpper' => true,
-                'minSpecial' => true,
                 'overall' => true,
                 'nonZxcvbnPass' => true,
             ],
@@ -158,9 +132,6 @@ class PasswordTest extends Test
                 'zxcvbnPass' => true,
                 'minLength' => true,
                 'maxLength' => true,
-                'minNum' => true,
-                'minUpper' => true,
-                'minSpecial' => true,
                 'overall' => true,
                 'nonZxcvbnPass' => true,
             ],
@@ -170,9 +141,6 @@ class PasswordTest extends Test
                 'zxcvbnPass' => false,
                 'minLength' => false,
                 'maxLength' => true,
-                'minNum' => false,
-                'minUpper' => false,
-                'minSpecial' => false,
                 'overall' => false,
                 'nonZxcvbnPass' => false,
             ],
@@ -182,9 +150,6 @@ class PasswordTest extends Test
                 'zxcvbnPass' => true,
                 'minLength' => true,
                 'maxLength' => true,
-                'minNum' => true,
-                'minUpper' => true,
-                'minSpecial' => true,
                 'overall' => true,
                 'nonZxcvbnPass' => true,
             ],
@@ -194,9 +159,6 @@ class PasswordTest extends Test
                 'zxcvbnPass' => true,
                 'minLength' => true,
                 'maxLength' => true,
-                'minNum' => false,
-                'minUpper' => false,
-                'minSpecial' => true,
                 'overall' => false,
                 'nonZxcvbnPass' => false,
             ],
@@ -206,9 +168,6 @@ class PasswordTest extends Test
                 'zxcvbnPass' => false,
                 'minLength' => false,
                 'maxLength' => true,
-                'minNum' => false,
-                'minUpper' => false,
-                'minSpecial' => false,
                 'overall' => false,
                 'nonZxcvbnPass' => false,
             ],
@@ -218,9 +177,6 @@ class PasswordTest extends Test
                 'zxcvbnPass' => false,
                 'minLength' => true,
                 'maxLength' => true,
-                'minNum' => true,
-                'minUpper' => true,
-                'minSpecial' => true,
                 'overall' => false,
                 'nonZxcvbnPass' => true,
             ],

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -44,9 +44,6 @@ api:
         ZXCVBN_API_BASEURL: http://zxcvbn:3000
         PASSWORD_RULE_minLength: 10
         PASSWORD_RULE_maxLength: 255
-        PASSWORD_RULE_minNum: 2
-        PASSWORD_RULE_minUpper: 1
-        PASSWORD_RULE_minSpecial: 1
         PASSWORD_RULE_minScore: 2
     encrypted_env_file: codeship.env.encrypted
     working_dir: /data

--- a/local.env.dist
+++ b/local.env.dist
@@ -134,15 +134,6 @@ ID_BROKER_validIpRanges=
 # Maximum password length, optional
 #PASSWORD_RULE_maxLength=255
 
-# Minimum number of numeric digits, optional
-#PASSWORD_RULE_minNum=2
-
-# Minimum number of upper-case letters, optional
-#PASSWORD_RULE_minUpper=1
-
-# Minimum number of special characters, optional
-#PASSWORD_RULE_minSpecial=0
-
 # Minimum ZXCVBN password score, optional
 #PASSWORD_RULE_minScore=3
 

--- a/test.env
+++ b/test.env
@@ -17,7 +17,4 @@ PASSWORDSTORE_CLASS=tests\mock\passwordstore\Component
 ZXCVBN_API_BASEURL=http://zxcvbn:3000
 PASSWORD_RULE_minLength=10
 PASSWORD_RULE_maxLength=255
-PASSWORD_RULE_minNum=2
-PASSWORD_RULE_minUpper=1
-PASSWORD_RULE_minSpecial=1
 PASSWORD_RULE_minScore=2


### PR DESCRIPTION
Remove `minNum`, `minUpper`, and `minSpecial` password rules. `minLength`, `maxLength`, and `minScore` are the remaining rules.