### PR TITLE
Redesign ID Broker personnelStore and passwordStore component tests

### DIFF
--- a/application/common/components/personnel/IdBroker.php
+++ b/application/common/components/personnel/IdBroker.php
@@ -137,6 +137,31 @@ class IdBroker extends Component implements PersonnelInterface
     }
 
     /**
+     * @param string $field
+     * @param string $value
+     * @return PersonnelUser
+     * @throws NotFoundException
+     * @throws \Exception
+     */
+    public function findByField($field, $value): PersonnelUser
+    {
+        $results = $this->listUsers($field, $value);
+
+        if (count($results) > 1) {
+            throw new \Exception(
+                sprintf('More than one user found when searching by %s "%s"', $field, $value),
+                1497636205
+            );
+        } elseif (count($results) === 1) {
+            if (mb_strtolower($results[0][$field]) == mb_strtolower($value)) {
+                return $this->returnPersonnelUserFromResponse($field, $value, $results[0]);
+            }
+        }
+
+        throw new NotFoundException();
+    }
+
+    /**
      * @param string $username
      * @return PersonnelUser
      * @throws NotFoundException
@@ -144,21 +169,7 @@ class IdBroker extends Component implements PersonnelInterface
      */
     public function findByUsername($username): PersonnelUser
     {
-        $idBrokerClient = $this->getIdBrokerClient();
-
-        $results = $idBrokerClient->listUsers(null, ['username' => $username]);
-        if (count($results) > 1) {
-            throw new \Exception(
-                sprintf('More than one user found when searching by username "%s"', $username),
-                1497636205
-            );
-        } elseif (count($results) === 1) {
-            if (mb_strtolower($results[0]['username']) == mb_strtolower($username)) {
-                return $this->returnPersonnelUserFromResponse('username', $username, $results[0]);
-            }
-        }
-
-        throw new NotFoundException();
+        return $this->findByField('username', $username);
     }
 
     /**
@@ -169,21 +180,7 @@ class IdBroker extends Component implements PersonnelInterface
      */
     public function findByEmail($email): PersonnelUser
     {
-        $idBrokerClient = $this->getIdBrokerClient();
-
-        $results = $idBrokerClient->listUsers(null, ['email' => $email]);
-        if (count($results) > 1) {
-            throw new \Exception(
-                sprintf('More than one user found when searching by email "%s"', $email),
-                1497636210
-            );
-        } elseif (count($results) === 1) {
-            if (mb_strtolower($results[0]['email']) == mb_strtolower($email)) {
-                return $this->returnPersonnelUserFromResponse('email', $email, $results[0]);
-            }
-        }
-
-        throw new NotFoundException();
+        return $this->findByField('email', $email);
     }
 
     /**
@@ -233,5 +230,19 @@ class IdBroker extends Component implements PersonnelInterface
         }
 
         return $this->returnPersonnelUserFromResponse('invite', '********', $userAttributes);
+    }
+
+    /**
+     * @param $field
+     * @param $value
+     * @return array
+     * @throws ServiceException
+     */
+    public function listUsers($field, $value): array
+    {
+        $idBrokerClient = $this->getIdBrokerClient();
+
+        $results = $idBrokerClient->listUsers(null, [$field => $value]);
+        return $results;
     }
 }

--- a/application/common/components/personnel/IdBroker.php
+++ b/application/common/components/personnel/IdBroker.php
@@ -59,10 +59,15 @@ class IdBroker extends Component implements PersonnelInterface
      * @param string $employeeId
      * @return PersonnelUser
      * @throws NotFoundException
+     * @throws ServiceException
      */
     public function findByEmployeeId($employeeId): PersonnelUser
     {
         $results = $this->callIdBrokerGetUser($employeeId);
+        if ($results === null) {
+            throw new NotFoundException();
+        }
+
         return $this->returnPersonnelUserFromResponse('employeeId', $employeeId, $results);
     }
 
@@ -71,7 +76,7 @@ class IdBroker extends Component implements PersonnelInterface
      *
      * @param string $employeeId
      * @return array|null
-     * @throws NotFoundException
+     * @throws ServiceException
      */
     public function callIdBrokerGetUser($employeeId)
     {
@@ -79,9 +84,6 @@ class IdBroker extends Component implements PersonnelInterface
         $idBrokerClient = $this->getIdBrokerClient();
 
         $results = $idBrokerClient->getUser($employeeId);
-        if ($results === null) {
-            throw new NotFoundException();
-        }
 
         return $results;
     }
@@ -233,12 +235,12 @@ class IdBroker extends Component implements PersonnelInterface
     }
 
     /**
-     * @param $field
-     * @param $value
-     * @return array
+     * @param string $field field name to search
+     * @param string $value search value
+     * @return array raw array of zero or more arrays of user properties
      * @throws ServiceException
      */
-    public function listUsers($field, $value): array
+    protected function listUsers($field, $value): array
     {
         $idBrokerClient = $this->getIdBrokerClient();
 

--- a/application/common/components/personnel/IdBroker.php
+++ b/application/common/components/personnel/IdBroker.php
@@ -1,7 +1,6 @@
 <?php
 namespace common\components\personnel;
 
-use IPBlock;
 use Sil\Idp\IdBroker\Client\IdBrokerClient;
 use Sil\Idp\IdBroker\Client\ServiceException;
 use yii\base\Component;
@@ -244,7 +243,6 @@ class IdBroker extends Component implements PersonnelInterface
     {
         $idBrokerClient = $this->getIdBrokerClient();
 
-        $results = $idBrokerClient->listUsers(null, [$field => $value]);
-        return $results;
+        return $idBrokerClient->listUsers(null, [$field => $value]);
     }
 }

--- a/application/composer.json
+++ b/application/composer.json
@@ -37,7 +37,6 @@
     "codeception/verify": "0.*",
     "behat/behat": "^3.3",
     "phpunit/phpunit": "^6.0",
-    "phake/phake": "^2.3",
     "silinternational/yii2-codeception": "dev-master"
   },
   "config": {

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c37d18c6fb8dba03bf16b10c62f98830",
+    "content-hash": "df473920c23964e509bf5e46cb574f83",
     "packages": [
         {
             "name": "adldap2/adldap2",
@@ -3790,64 +3790,6 @@
                 "object graph"
             ],
             "time": "2018-06-11T23:09:50+00:00"
-        },
-        {
-            "name": "phake/phake",
-            "version": "v2.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mlively/Phake.git",
-                "reference": "d5832f1a0dd2370e14d38bcbaeb6770e8546cff2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mlively/Phake/zipball/d5832f1a0dd2370e14d38bcbaeb6770e8546cff2",
-                "reference": "d5832f1a0dd2370e14d38bcbaeb6770e8546cff2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "sebastian/comparator": "~1.1"
-            },
-            "require-dev": {
-                "codeclimate/php-test-reporter": "dev-master",
-                "doctrine/common": "2.3.*",
-                "ext-soap": "*",
-                "hamcrest/hamcrest-php": "1.1.*",
-                "phpunit/phpunit": "3.7.*"
-            },
-            "suggest": {
-                "doctrine/common": "Allows mock annotations to use import statements for classes.",
-                "hamcrest/hamcrest-php": "Use Hamcrest matchers."
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Phake": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Mike Lively",
-                    "email": "m@digitalsandwich.com"
-                }
-            ],
-            "description": "The Phake mock testing library",
-            "homepage": "https://github.com/mlively/Phake",
-            "keywords": [
-                "mock",
-                "testing"
-            ],
-            "time": "2017-03-20T05:16:34+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/application/tests/unit/common/components/IdBrokerPwTest.php
+++ b/application/tests/unit/common/components/IdBrokerPwTest.php
@@ -2,7 +2,6 @@
 namespace tests\unit\common\components;
 
 use PHPUnit\Framework\TestCase;
-use Phake;
 use common\components\passwordStore\AccountLockedException;
 use common\components\passwordStore\IdBroker;
 use common\components\passwordStore\UserNotFoundException;
@@ -15,14 +14,21 @@ class IdBrokerPwTest extends TestCase
      * array of users' information.
      *
      * @param array $listOfUserData
-     * @return IdBroker
+     * @return \PHPUnit_Framework_MockObject_MockObject
      */
     protected function getIdBrokerForTest($listOfUserData)
     {
         $fakeIdBrokerClient = new FakeIdBrokerClient($listOfUserData);
-        $idBrokerForTest = Phake::partialMock(IdBroker::class);
-        Phake::when($idBrokerForTest)->getClient()->thenReturn($fakeIdBrokerClient);
-        return $idBrokerForTest;
+
+        $brokerMock = $this->getMockBuilder(IdBroker::class)
+            ->setMethods(['getClient'])
+            ->getMock();
+
+        $brokerMock->expects($this->any())
+            ->method('getClient')
+            ->willReturn($fakeIdBrokerClient);
+
+        return $brokerMock;
     }
 
     public function testGetMetaOk()

--- a/application/tests/unit/common/components/IdBrokerTest.php
+++ b/application/tests/unit/common/components/IdBrokerTest.php
@@ -2,8 +2,8 @@
 namespace tests\unit\common\components;
 
 use PHPUnit\Framework\TestCase;
-use common\components\personnel\NotFoundException;
 use common\components\personnel\IdBroker;
+use common\components\personnel\NotFoundException;
 
 class IdBrokerTest extends TestCase
 {

--- a/application/tests/unit/common/components/IdBrokerTest.php
+++ b/application/tests/unit/common/components/IdBrokerTest.php
@@ -128,91 +128,37 @@ class IdBrokerTest extends TestCase
 
     public function testFindByUsername()
     {
-        $employeeId = '33333';
-        $firstName = 'Tommy';
-        $lastName = 'Tester';
-        $userName = 'tommy_tester3';
-        $email = $userName . '@any.org';
+        $mockReturnValue[] = $this->getMockReturnValue();
+        $brokerMock = $this->getMockBuilder('common\components\personnel\IdBroker')
+            ->setMethods(['listUsers'])
+            ->getMock();
+        $brokerMock->expects($this->any())
+            ->method('listUsers')
+            ->willReturn($mockReturnValue);
 
-        // Setup
-        $this->ensureUserExists([
-            'employee_id' => $employeeId,
-            'first_name' => $firstName,
-            'last_name' => $lastName,
-            'username' => $userName,
-            'email' => $email,
-            'hide' => 'no',
-        ]);
+        $username = $mockReturnValue[0]['username'];
+        $results = $brokerMock->findByUsername($username);
 
-        // Act
-        $results = $this->getIdBroker()->findByUsername($userName);
-
-        // Assert
-        $this->assertResultPropertiesMatch($results, [
-            'employeeId' => $employeeId,
-            'username' => $userName,
-            'email' => $email,
-        ]);
+        $msg = ' *** Bad results for username';
+        $this->assertEquals($username, $results->username, $msg);
     }
 
     public function testFindByEmail()
     {
-        $employeeId = '44444';
-        $firstName = 'Tommy';
-        $lastName = 'Tester';
-        $userName = 'tommy_tester4';
-        $email = $userName . '@any.org';
+        $mockReturnValue[] = $this->getMockReturnValue();
+        $brokerMock = $this->getMockBuilder('common\components\personnel\IdBroker')
+            ->setMethods(['listUsers'])
+            ->getMock();
+        $brokerMock->expects($this->any())
+            ->method('listUsers')
+            ->willReturn($mockReturnValue);
 
-        // Setup
-        $this->ensureUserExists([
-            'employee_id' => $employeeId,
-            'first_name' => $firstName,
-            'last_name' => $lastName,
-            'username' => $userName,
-            'email' => $email,
-            'hide' => 'no',
-        ]);
+        $email = $mockReturnValue[0]['email'];
+        $results = $brokerMock->findByEmail($email);
 
-        // Act
-        $results = $this->getIdBroker()->findByEmail($email);
-
-        // Assert
-        $this->assertResultPropertiesMatch($results, [
-            'employeeId' => $employeeId,
-            'username' => $userName,
-            'email' => $email,
-        ]);
+        $msg = ' *** Bad results for email';
+        $this->assertEquals($email, $results->email, $msg);
     }
-
-    public function testFindByEmployeeId()
-    {
-        $employeeId = '55555';
-        $firstName = 'Tommy';
-        $lastName = 'Tester';
-        $userName = 'tommy_tester5';
-        $email = $userName . '@any.org';
-
-        // Setup
-        $this->ensureUserExists([
-            'employee_id' => $employeeId,
-            'first_name' => $firstName,
-            'last_name' => $lastName,
-            'username' => $userName,
-            'email' => $email,
-            'hide' => 'no',
-        ]);
-
-        // Act
-        $results = $this->getIdBroker()->findByEmployeeId($employeeId);
-
-        // Assert
-        $this->assertResultPropertiesMatch($results, [
-            'employeeId' => $employeeId,
-            'username' => $userName,
-            'email' => $email,
-        ]);
-    }
-
 
     public function testFindByEmployeeId_MissingUser()
     {

--- a/application/tests/unit/common/components/IdBrokerTest.php
+++ b/application/tests/unit/common/components/IdBrokerTest.php
@@ -7,26 +7,6 @@ use common\components\personnel\NotFoundException;
 
 class IdBrokerTest extends TestCase
 {
-    /**
-     * @param string $mockedMethod name of method to replace with mocked implementation
-     * @param mixed $returnValue return value from mocked method
-     * @return \PHPUnit_Framework_MockObject_MockObject
-     */
-    public function getMockComponent($mockedMethod = null, $returnValue = null)
-    {
-        $brokerMock = $this->getMockBuilder(IdBroker::class)
-            ->setMethods(['callIdBrokerGetUser', 'listUsers'])
-            ->getMock();
-
-        if ($mockedMethod) {
-            $brokerMock->expects($this->any())
-                ->method($mockedMethod)
-                ->willReturn($returnValue);
-        }
-
-        return $brokerMock;
-    }
-
     private function getMockReturnValue()
     {
         return [
@@ -171,5 +151,25 @@ class IdBrokerTest extends TestCase
                 $propertyValue
             ));
         }
+    }
+    
+    /**
+     * @param string $mockedMethod name of method to replace with mocked implementation
+     * @param mixed $returnValue return value from mocked method
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    public function getMockComponent($mockedMethod = null, $returnValue = null)
+    {
+        $brokerMock = $this->getMockBuilder(IdBroker::class)
+            ->setMethods(['callIdBrokerGetUser', 'listUsers'])
+            ->getMock();
+
+        if ($mockedMethod) {
+            $brokerMock->expects($this->any())
+                ->method($mockedMethod)
+                ->willReturn($returnValue);
+        }
+
+        return $brokerMock;
     }
 }


### PR DESCRIPTION
Use mocked class instead of an actual `idp-id-broker` Docker container. The model unit tests and the `api` Codeception suite still exercise the broker API interface.