### PR TITLE
Support `unicodePwd` field in idp-pw-api Ldap password store

### DIFF
--- a/application/common/components/passwordStore/Ldap.php
+++ b/application/common/components/passwordStore/Ldap.php
@@ -189,6 +189,9 @@ class Ldap extends Component implements PasswordStoreInterface
          */
         $this->assertUserNotDisabled($user);
 
+        if ($this->userPasswordAttribute === 'unicodePwd') {
+            $password = $this->encodeForUnicodePwdField($password);
+        }
 
         /*
          * Update password
@@ -261,6 +264,28 @@ class Ldap extends Component implements PasswordStoreInterface
         return $this->getMeta($employeeId);
     }
 
+    /**
+     * Encode the given password as necessary for use in the `unicodePwd` field.
+     *
+     * For details, see
+     * https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/6e803168-f140-4d23-b2d3-c3a8ab5917d2
+     *
+     * @param $password
+     * @return false|string
+     * @throws \Exception
+     */
+    protected function encodeForUnicodePwdField($password)
+    {
+        $encodedPassword = iconv('UTF-8', 'UTF-16LE', '"' . $password . '"');
+        if ($encodedPassword === false) {
+            throw new \Exception(
+                'Did not set password: Cannot encode it properly.',
+                1554296385
+            );
+        }
+        return $encodedPassword;
+    }
+    
     /**
      * @param \Adldap\Models\Entry $user
      * @return bool

--- a/application/composer.json
+++ b/application/composer.json
@@ -10,6 +10,7 @@
   ],
   "require": {
     "php": ">=7.0",
+    "ext-iconv": "*",
     "yiisoft/yii2": "~2.0.15",
     "yiisoft/yii2-swiftmailer": "*",
     "yiisoft/yii2-gii": "*",


### PR DESCRIPTION
**Added:**
- Will properly encode passwords for storing in the `unicodePwd` field when applicable.