### PR TITLE
Small cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ testunit: composer rmTestDb upTestDb broker ldapload yiimigratetestDb
 	# create folder as user before test creates it as root
 	mkdir -p application/tests/_output
 	docker-compose run --rm unittest
-	sed -i "s|/data/|`pwd`/application/|" application/tests/_output/coverage.xml
+	sed -i '' "s|/data/|`pwd`/application/|" application/tests/_output/coverage.xml
 
 testapi: upTestDb yiimigratetestDb
 	docker-compose kill broker

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Backend API for Identity Provider Password Management
 2. Docker Compose >= 1.5
 
 ### Mac
-1. Docker for Mac Beta
+1. Docker for Mac
 
 ### Windows
 1. VirtualBox
@@ -28,6 +28,7 @@ Backend API for Identity Provider Password Management
    This will run some of the containers as you so that they can write to your host filesystem
    and the file permissions will be owned by you. On Mac (and possibly other *nix-based
    systems), this can be done by running this: `export DOCKER_UIDGID="$(id -u):$(id -g)"`
+   (even in your `.bash_profile` file).
 4. Setup environment variable for ```COMPOSER_CONFIG_FILE``` with the full system path
    to your composer config.json file, for example: ```/home/my/.composer/config.json```.
    This will allow the composer container to use your github auth token when pulling dependencies.

--- a/application/run-tests.sh
+++ b/application/run-tests.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+set -e
+
 # Install composer dev dependencies
 cd /data
-runny composer install --prefer-dist --no-interaction --optimize-autoloader
+composer install --prefer-dist --no-interaction --optimize-autoloader
 
 mkdir -p /data/runtime/mail
 
@@ -14,18 +16,7 @@ apt-get install -y php-xdebug
 
 # Run codeception tests
 whenavail broker 80 100 echo "broker ready, running unit tests..."
-runny ./vendor/bin/codecept run unit --coverage --coverage-xml
-TESTRESULTS_UNIT=$?
+./vendor/bin/codecept run unit --coverage --coverage-xml
 
 # Run local behat tests
-runny ./vendor/bin/behat --config=tests/features/behat.yml --strict --profile=local
-TESTRESULTS_BEHAT=$?
-
-# If unit tests fail, make sure to exit with error status
-if [[ "$TESTRESULTS_UNIT" -ne 0 ]]; then
-    exit $TESTRESULTS_UNIT
-fi
-
-if [[ "$TESTRESULTS_BEHAT" -ne 0 ]]; then
-    exit $TESTRESULTS_BEHAT
-fi
+./vendor/bin/behat --config=tests/features/behat.yml --strict --profile=local

--- a/application/run-tests.sh
+++ b/application/run-tests.sh
@@ -21,20 +21,6 @@ TESTRESULTS_UNIT=$?
 runny ./vendor/bin/behat --config=tests/features/behat.yml --strict --profile=local
 TESTRESULTS_BEHAT=$?
 
-## The ocular.php script sometimes works and sometimes hangs with no error message
-
-# Clone repo to get git parents
-#cd /tmp
-#rm -rf idp-pw-api/
-#git clone https://github.com/silinternational/idp-pw-api.git
-#cd idp-pw-api/
-#PARENTS=`git log --pretty=%P -n 1 ${CI_COMMIT_ID}`
-
-# Push coverage data to scrutinizer
-#cd /data
-#curl -Lo ocular.phar https://scrutinizer-ci.com/ocular.phar
-#php ocular.phar code-coverage:upload --repository="g/silinternational/idp-pw-api" --revision="${CI_COMMIT_ID}" --parent="${PARENTS}" --format=php-clover -n -vvv tests/_output/coverage.xml
-
 # If unit tests fail, make sure to exit with error status
 if [[ "$TESTRESULTS_UNIT" -ne 0 ]]; then
     exit $TESTRESULTS_UNIT

--- a/local.env.dist
+++ b/local.env.dist
@@ -173,10 +173,10 @@ AUTH_SAML_sloUrl=
 
 
 # === memcache config for session storage ===
-MEMCACHE_CONFIG1_host=
+MEMCACHE_CONFIG1_host=memcache1
 MEMCACHE_CONFIG1_port=11211
 MEMCACHE_CONFIG1_weight=100
-MEMCACHE_CONFIG2_host=
+MEMCACHE_CONFIG2_host=memcache2
 MEMCACHE_CONFIG2_port=11211
 MEMCACHE_CONFIG2_weight=50
 


### PR DESCRIPTION
These are a few other changes I saw in my recent idp-pw-api testing changes, but it seemed better to submit them as a separate PR. Please feel free to push back and/or suggest changes if you think any of this isn't a good approach.

Summary:
- On a Mac, the `sed` call fails because it's expecting a string after the `-i` flag telling it what extension to use for a backup copy of the file being modified.
- The `run-tests.sh` file doesn't need to use runny, since we don't need it to send the output to Logentries when we run tests.
- I also remove the `TESTRESULTS_...` checks, replacing that logic with a `set -e` at the beginning of the script which accomplishes that result.