### PR TITLE
patch to help recover from an expired login session

### DIFF
--- a/application/frontend/controllers/AuthController.php
+++ b/application/frontend/controllers/AuthController.php
@@ -46,8 +46,9 @@ class AuthController extends BaseRestController
 
     public function actionLogin()
     {
+        $afterLogin = $this->getAfterLoginUrl($this->getReturnTo());
+
         if ( ! \Yii::$app->user->isGuest) {
-            $afterLogin = $this->getAfterLoginUrl($this->getReturnTo());
             return $this->redirect($afterLogin);
         }
 
@@ -63,7 +64,12 @@ class AuthController extends BaseRestController
             try {
                 $clientId = Utils::getClientIdOrFail();
             } catch (\Exception $e) {
-                throw new BadRequestHttpException(\Yii::t('app', 'Auth.MissingClientID'), 1545316879);
+                \Yii::warning(\Yii::t('app', 'Auth.MissingClientID'));
+
+                // This condition happens if a user sits on the IDP login prompt long
+                // enough for the session to expire. As a workaround, redirect back to
+                // a profile UI page, which should restart the login process
+                return $this->redirect($afterLogin);
             }
 
             /*

--- a/application/frontend/controllers/AuthController.php
+++ b/application/frontend/controllers/AuthController.php
@@ -46,10 +46,8 @@ class AuthController extends BaseRestController
 
     public function actionLogin()
     {
-        $afterLogin = $this->getAfterLoginUrl($this->getReturnTo());
-
         if ( ! \Yii::$app->user->isGuest) {
-            return $this->redirect($afterLogin);
+            return $this->redirect($this->getAfterLoginUrl($this->getReturnTo()));
         }
 
         /*
@@ -68,8 +66,8 @@ class AuthController extends BaseRestController
 
                 // This condition happens if a user sits on the IDP login prompt long
                 // enough for the session to expire. As a workaround, redirect back to
-                // a profile UI page, which should restart the login process
-                return $this->redirect($afterLogin);
+                // the profile UI home page, which should restart the login process.
+                return $this->redirect(\Yii::$app->params['uiUrl']);
             }
 
             /*

--- a/application/tests/api/AuthCest.php
+++ b/application/tests/api/AuthCest.php
@@ -10,7 +10,7 @@ class AuthCest extends BaseCest
         $I->wantTo('check response when making a GET request for logging in with no client_id');
         $I->stopFollowingRedirects();
         $I->sendGET('/auth/login');
-        $I->seeResponseCodeIs(400);
+        $I->seeResponseCodeIs(302);
     }
 
     public function test2(ApiTester $I)


### PR DESCRIPTION
A user will see an error page from the API if they sit on the IDP login prompt long enough for the session to expire, and then proceed with the login attempt. This patch does a redirect back to a profile UI page, which should restart the login process.

![image](https://user-images.githubusercontent.com/3172830/103038397-97f10f00-452b-11eb-9c8c-88fc6cd14d3c.png)
