### PR TITLE
allow a list of hosts in ldap config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ application/tests/_support/_generated/
 api.html
 
 dockercfg
+*.crt

--- a/application/common/components/passwordStore/Ldap.php
+++ b/application/common/components/passwordStore/Ldap.php
@@ -11,7 +11,7 @@ class Ldap extends Component implements PasswordStoreInterface
     /** @var string */
     public $baseDn;
 
-    /** @var string */
+    /** @var string|string[] */
     public $host;
 
     /** @var integer default=636 */
@@ -83,31 +83,71 @@ class Ldap extends Component implements PasswordStoreInterface
      */
     public function connect()
     {
+        // Connection has already been established
+        if ($this->ldapClient !== null) {
+            return;
+        }
+
         if ($this->useSsl && $this->useTls) {
             // Prefer TLS over SSL
             $this->useSsl = false;
         }
 
-        /*
-         * Initialize provider with configuration
-         */
-        $this->ldapClient = new Adldap();
-        $this->ldapClient->addProvider([
+        // ensure the `host` property is an array
+        $this->host = is_array($this->host) ? $this->host : [$this->host];
+
+        // iterate over the list of hosts to find the first one that is good
+        foreach ($this->host as $host) {
+            $client = $this->connectHost($host);
+            if ($client !== null) {
+                $this->ldapClient = new Adldap();
+                return;
+            }
+        }
+
+        // Wasn't able to connect to any of the provided LDAP hosts
+        if ($this->ldapClient === null) {
+            throw new \Exception(
+                "failed to connect to " . $this->displayName . " host",
+                1611157472
+            );
+        }
+    }
+
+    /**
+     * @param string $host
+     * @return Adldap|null
+     */
+    private function connectHost(string $host)
+    {
+        $client = new Adldap();
+        $client->addProvider([
             'base_dn' => $this->baseDn,
-            'hosts' => [$this->host],
+            'hosts' => [$host],
             'port' => $this->port,
             'username' => $this->adminUsername,
             'password' => $this->adminPassword,
             'use_ssl' => $this->useSsl,
             'use_tls' => $this->useTls,
             'schema' => OpenLDAP::class,
+            'timeout' => 3,
         ]);
 
         try {
-            $this->ldapProvider = $this->ldapClient->connect();
+            $this->ldapProvider = $client->connect();
         } catch (BindException $e) {
-            throw new \Exception($e->getDetailedError());
+            $err = $e->getDetailedError();
+            \Yii::warning([
+                'action' => 'ldap connect host',
+                'status' => 'warning',
+                'host' => $host,
+                'ldap_code' => $err->getErrorCode(),
+                'diagnostic' => $err->getDiagnosticMessage(),
+                'message' => $err->getErrorMessage(),
+            ]);
+            return null;
         }
+        return $client;
     }
 
     /**

--- a/application/common/components/passwordStore/Ldap.php
+++ b/application/common/components/passwordStore/Ldap.php
@@ -100,7 +100,7 @@ class Ldap extends Component implements PasswordStoreInterface
         foreach ($this->host as $host) {
             $client = $this->connectHost($host);
             if ($client !== null) {
-                $this->ldapClient = new Adldap();
+                $this->ldapClient = $client;
                 return;
             }
         }

--- a/application/common/components/passwordStore/Ldap.php
+++ b/application/common/components/passwordStore/Ldap.php
@@ -130,7 +130,7 @@ class Ldap extends Component implements PasswordStoreInterface
             'use_ssl' => $this->useSsl,
             'use_tls' => $this->useTls,
             'schema' => OpenLDAP::class,
-            'timeout' => 3,
+            'timeout' => 3, // set connection timeout to 3 seconds, default is 5 seconds
         ]);
 
         try {


### PR DESCRIPTION
Iterate through the list of hosts and hold on to the first one that works so it doesn't have to do that each time `connect` is called, which can be several times in one request.