### PR TITLE
Release 5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [5.3.3]
+## [5.3.4]
 ### Fixed
 - Improved handling of expired session on login
+
+## [5.3.3]
+### Fixed
+- Updated dependencies
+- Rotated credentials for CI/CD
 
 ## [5.3.2]
 ### Fixed
@@ -133,7 +138,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version of Password Manager Backend.
 
-[Unreleased]: https://github.com/silinternational/idp-pw-api/compare/5.3.3...HEAD
+[Unreleased]: https://github.com/silinternational/idp-pw-api/compare/5.3.4...HEAD
+[5.3.4]: https://github.com/silinternational/idp-pw-api/compare/5.3.3..5.3.4
 [5.3.3]: https://github.com/silinternational/idp-pw-api/compare/5.3.2..5.3.3
 [5.3.2]: https://github.com/silinternational/idp-pw-api/compare/5.3.1..5.3.2
 [5.3.1]: https://github.com/silinternational/idp-pw-api/compare/5.3.0..5.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [5.3.3]
+### Fixed
+- Improved handling of expired session on login
+
 ## [5.3.2]
-### Fixed 
+### Fixed
 - Changed Docker credentials
 
 ## [5.3.1]
@@ -129,7 +133,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version of Password Manager Backend.
 
-[Unreleased]: https://github.com/silinternational/idp-pw-api/compare/5.3.2...HEAD
+[Unreleased]: https://github.com/silinternational/idp-pw-api/compare/5.3.3...HEAD
+[5.3.3]: https://github.com/silinternational/idp-pw-api/compare/5.3.2..5.3.3
 [5.3.2]: https://github.com/silinternational/idp-pw-api/compare/5.3.1..5.3.2
 [5.3.1]: https://github.com/silinternational/idp-pw-api/compare/5.3.0..5.3.1
 [5.3.0]: https://github.com/silinternational/idp-pw-api/compare/5.2.2...5.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [5.4.0]
+### Added
+- Allow LDAP host name to be a list of hostname strings as well as a single string for backward compatibility
+
 ## [5.3.4]
 ### Fixed
 - Improved handling of expired session on login
@@ -138,7 +142,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version of Password Manager Backend.
 
-[Unreleased]: https://github.com/silinternational/idp-pw-api/compare/5.3.4...HEAD
+[Unreleased]: https://github.com/silinternational/idp-pw-api/compare/5.4.0..HEAD
+[5.4.0]: https://github.com/silinternational/idp-pw-api/compare/5.3.4..5.4.0
 [5.3.4]: https://github.com/silinternational/idp-pw-api/compare/5.3.3..5.3.4
 [5.3.3]: https://github.com/silinternational/idp-pw-api/compare/5.3.2..5.3.3
 [5.3.2]: https://github.com/silinternational/idp-pw-api/compare/5.3.1..5.3.2

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 SIL International
+Copyright (c) 2021 SIL International
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Added
- Allow LDAP host name to be a list of hostname strings as well as a single string for backward compatibility
