### PR TITLE
Don't send email alert for bad email-service check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- Don't send email alerts for system/status errors that are likely transient
+- Don't send email alerts for /site/system-status errors that are likely transient
 
 ## [5.5.3]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Don't send email alerts for system/status errors that are likely transient
 
 ## [5.5.3]
 ### Added

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -127,6 +127,7 @@ return [
                         'yii\web\HttpException:410',
                         'yii\web\HttpException:422',
                         'yii\web\HttpException:429',
+                        'yii\web\HttpException:502',
                         'Sil\EmailService\Client\EmailServiceClientException',
                     ],
                     'logVars' => [], // Disable logging of _SERVER, _POST, etc.

--- a/application/frontend/controllers/SiteController.php
+++ b/application/frontend/controllers/SiteController.php
@@ -4,12 +4,10 @@ namespace frontend\controllers;
 use common\components\Emailer;
 use Exception;
 use frontend\components\BaseRestController;
-use Sil\EmailService\Client\EmailServiceClient;
 use yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
 use yii\web\HttpException;
 use yii\web\MethodNotAllowedHttpException;
-use yii\web\ServerErrorHttpException;
 use yii\web\UnauthorizedHttpException;
 
 /**

--- a/application/frontend/controllers/SiteController.php
+++ b/application/frontend/controllers/SiteController.php
@@ -7,6 +7,7 @@ use frontend\components\BaseRestController;
 use Sil\EmailService\Client\EmailServiceClient;
 use yii\filters\AccessControl;
 use yii\helpers\ArrayHelper;
+use yii\web\HttpException;
 use yii\web\MethodNotAllowedHttpException;
 use yii\web\ServerErrorHttpException;
 use yii\web\UnauthorizedHttpException;
@@ -16,6 +17,7 @@ use yii\web\UnauthorizedHttpException;
  */
 class SiteController extends BaseRestController
 {
+    const HttpExceptionBadGateway = 502;
 
     public $layout = false;
 
@@ -67,6 +69,9 @@ class SiteController extends BaseRestController
         throw new MethodNotAllowedHttpException();
     }
 
+    /**
+     * @throws HttpException
+     */
     public function actionSystemStatus()
     {
         /**
@@ -75,12 +80,12 @@ class SiteController extends BaseRestController
         try {
             \Yii::$app->db->open();
         } catch (Exception $e) {
-            throw new ServerErrorHttpException(
+            throw new HttpException(self::HttpExceptionBadGateway,
                 'Unable to connect to db, error code ' . $e->getCode(),
                 $e->getCode()
             );
         }
-        
+
         try {
             /**
              * @var $emailer Emailer
@@ -89,7 +94,10 @@ class SiteController extends BaseRestController
             $emailer->getSiteStatus();
         } catch (\Exception $e) {
             \Yii::error($e->getMessage());
-            throw new ServerErrorHttpException('Problem with email service.');
+            throw new HttpException(self::HttpExceptionBadGateway,
+                'Problem with email service.',
+                $e->getCode()
+            );
         }
     }
 }


### PR DESCRIPTION
Use http 502 (bad gateway) for email-service status check and database status check, and exclude it from the email alert. Since this is triggered either by NodePing or by AWS ECS, a true outage will be reported or addressed by those services.