### PR TITLE
allow a short name to be contained in a password

### DIFF
--- a/application/common/models/Password.php
+++ b/application/common/models/Password.php
@@ -115,6 +115,10 @@ class Password extends Model
         }
 
         foreach ($params as $disallowedAttribute) {
+            // Don't apply this check to attributes with a very short value
+            if (strlen($this->user->$disallowedAttribute) < 3) {
+                continue;
+            }
             if (mb_strpos(mb_strtolower($this->{$attribute}),
                 mb_strtolower($this->user->$disallowedAttribute)) !== false) {
                 $this->addError($attribute, \Yii::t(

--- a/application/tests/api/PasswordCest.php
+++ b/application/tests/api/PasswordCest.php
@@ -213,4 +213,20 @@ class PasswordCest extends BaseCest
         $I->sendPUT('/password', ['password' => 'a_password']);
         $I->seeResponseCodeIs(401);
     }
+
+    public function test24(ApiTester $I)
+    {
+        $I->wantTo('check response when changing the password (PUT request) to something that contains a short first_name');
+        $I->haveHttpHeader('Authorization', 'Bearer user6');
+        $I->sendPUT('/password', ['password' => 'aUsz56789!']);
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function test25(ApiTester $I)
+    {
+        $I->wantTo('check response when changing the password (PUT request) to something that contains a short last_name');
+        $I->haveHttpHeader('Authorization', 'Bearer user6');
+        $I->sendPUT('/password', ['password' => 'aSxz56789!']);
+        $I->seeResponseCodeIs(200);
+    }
 }

--- a/application/tests/api/fixtures/data/User.php
+++ b/application/tests/api/fixtures/data/User.php
@@ -69,4 +69,18 @@ return [
         'auth_type' => 'reset',
         'hide' => 'no',
     ],
+    'user6' => [
+        'id' => 6,
+        'uuid' => '66ba13fe-d4ec-40be-baaa-ee07ce1d9438',
+        'employee_id' => '6',
+        'first_name' => 'Us',
+        'last_name' => 'Sx',
+        'idp_username' => 'us_sx',
+        'email' => 'us_sx@organization.org',
+        'created' => '2016-03-29 11:58:00',
+        'access_token' => Utils::getAccessTokenHash('user6'),
+        'access_token_expiration' => Utils::getDatetime(time() + 1800),
+        'auth_type' => 'reset',
+        'hide' => 'no',
+    ],
 ];


### PR DESCRIPTION
This is a fix for https://trello.com/c/V1tb0LAo/556-dont-prevent-password-from-including-first-last-name-if-that-name-is-less-than-3-characters-long