### PR TITLE
IDP-862 -- configure Sentry to not send request bodies in log data

### DIFF
--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -182,6 +182,7 @@ return [
                         'attach_stacktrace' => false, // stack trace identifies the logger call stack, not helpful
                         'environment' => YII_ENV,
                         'release' => 'idp-pw-api@develop',
+                        'max_request_body_size' => 'never', // never send request bodies
                         'before_send' => function (Event $event) use ($idpName): ?Event {
                             $event->setExtra(['idp' => $idpName]);
                             return $event;


### PR DESCRIPTION

### Security
- Do net send HTTP request body in log data sent to Sentry

[IDP-862](https://itse.youtrack.cloud/issue/IDP-862)
