### PR TITLE
Release 6.6.3 -- don't log request data

### DIFF
--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -181,7 +181,7 @@ return [
                     'clientOptions' => [
                         'attach_stacktrace' => false, // stack trace identifies the logger call stack, not helpful
                         'environment' => YII_ENV,
-                        'release' => 'idp-pw-api@6.6.2',
+                        'release' => 'idp-pw-api@develop',
                         'before_send' => function (Event $event) use ($idpName): ?Event {
                             $event->setExtra(['idp' => $idpName]);
                             return $event;

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -181,7 +181,7 @@ return [
                     'clientOptions' => [
                         'attach_stacktrace' => false, // stack trace identifies the logger call stack, not helpful
                         'environment' => YII_ENV,
-                        'release' => 'idp-pw-api@6.6.1',
+                        'release' => 'idp-pw-api@develop',
                         'before_send' => function (Event $event) use ($idpName): ?Event {
                             $event->setExtra(['idp' => $idpName]);
                             return $event;

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -181,7 +181,7 @@ return [
                     'clientOptions' => [
                         'attach_stacktrace' => false, // stack trace identifies the logger call stack, not helpful
                         'environment' => YII_ENV,
-                        'release' => 'idp-pw-api@develop',
+                        'release' => 'idp-pw-api@6.6.3',
                         'max_request_body_size' => 'never', // never send request bodies
                         'before_send' => function (Event $event) use ($idpName): ?Event {
                             $event->setExtra(['idp' => $idpName]);


### PR DESCRIPTION

### Changed
- Configure Sentry to not send request body data to Sentry logging servers.

---

### Release PR Checklist
- [x] Update version number in main.php Sentry configuration
