### PR TITLE
validate password does not contain null byte

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,13 @@ The chart below summarizes the test configuration.
 |       |             | config    | tests/api.suite.yml  | (same)                  |
 |       |             | coverage  | controllers          | (same)                  |
 |-------|-------------|-----------|----------------------| ----------------------- |
+
+### Running tests
+
+To run all tests, use `make test`.
+
+To run a single unit test:
+
+```
+docker compose run --rm unittest vendor/bin/codecept run tests/unit/common/models/PasswordTest.php:testBadBytes
+```

--- a/application/common/models/Password.php
+++ b/application/common/models/Password.php
@@ -83,6 +83,10 @@ class Password extends Model
             [
                 'password', 'passwordStoreInterfaceAssess',
                 'skipOnError' => true,
+            ],
+            [
+                'password', 'validateNoBadBytes',
+                'skipOnError' => false,
             ]
         ];
     }
@@ -275,6 +279,13 @@ class Password extends Model
             } else {
                 throw new \Exception('Password.UnknownProblem');
             }
+        }
+    }
+
+    public function validateNoBadBytes($attribute)
+    {
+        if (str_contains($this->$attribute, "\0")) {
+            $this->addError($attribute, \Yii::t('app', 'Password.ContainsBadByte'));
         }
     }
 }

--- a/application/frontend/messages/en/app.php
+++ b/application/frontend/messages/en/app.php
@@ -42,6 +42,7 @@ return [
     'Multiple.SetPartialSuccess' => 'Successfully set the password in {successes}, but failed to set the password in {errors}. Contact {supportName} at {supportEmail} for assistance.',
     'Multiple.SetFailed' => 'Failed to set the password in {errors}. Contact {supportName} at {supportEmail} for assistance.',
     'Password.Breached' => 'The password you entered was previously discovered in a data breach of a different website. It may or may not have been your own account that was compromised. Please use a different password here and then visit <a href="https://sites.google.com/sil.org/identityaccounts/logging-in/password-recommendations" target="_blank">this help page</a> to learn more.',
+    'Password.ContainsBadByte' => 'Password contains a disallowed character',
     'Password.DisallowedContent' => 'Your password may not contain any of these: {labelList} (code 180)',
     'Password.MissingPassword' => 'Password is required',
     'Password.PasswordReuse' => 'Unable to update password. If this password has been used before please use something different.',

--- a/application/frontend/messages/es/app.php
+++ b/application/frontend/messages/es/app.php
@@ -42,6 +42,7 @@ return [
     'Multiple.SetPartialSuccess' => 'Estableció correctamente la contraseña en {successes}, pero no pudo establecer la contraseña en {errors}. Póngase en contacto con {supportName} en {supportEmail} para obtener ayuda.',
     'Multiple.SetFailed' => 'Error al establecer la contraseña en {errors}. Póngase en contacto con {supportName} en {supportEmail} para obtener ayuda.',
     'Password.Breached' => 'La contraseña que ingresó fue descubierta previamente en una violación de datos de un sitio web diferente. Puede o no haber sido su propia cuenta la que se vio comprometida. Utilice una contraseña diferente aquí y luego visite <a href="https://sites.google.com/sil.org/identityaccounts/logging-in/password-recommendations" target="_blank">esta página de ayuda</a> para obtener más información.',
+    'Password.ContainsBadByte' => 'La contraseña contiene un carácter no permitido',
     'Password.DisallowedContent' => 'Su contraseña no puede contener ninguno de estos: {labelList} (código 180)',
     'Password.MissingPassword' => 'Se requiere contraseña',
     'Password.PasswordReuse' => 'No se puede actualizar la contraseña. Si esta contraseña ha sido usada antes, use algo diferente.',

--- a/application/frontend/messages/fr/app.php
+++ b/application/frontend/messages/fr/app.php
@@ -42,6 +42,7 @@ return [
     'Multiple.SetPartialSuccess' => 'Le mot de passe a été bien défini sur {successes}, mais pas sur {errors}. Contactez {supportName} à {supportEmail} pour obtenir de l\'aide.',
     'Multiple.SetFailed' => 'Impossible de définir le mot de passe sur {errors}. Contactez {supportName} à {supportEmail} pour obtenir de l\'aide.',
     'Password.Breached' => 'Le mot de passe que vous avez entré a déjà été découvert dans une violation de données d\'un site Web différent. Votre compte a peut-être été compromis ou non. Veuillez utiliser un mot de passe différent ici, puis visitez <a href="https://sites.google.com/sil.org/identityaccounts/logging-in/password-recommendations" target="_blank">cette page d’aide</a> pour en savoir plus.',
+    'Password.ContainsBadByte' => 'Le mot de passe contient un caractère non autorisé',
     'Password.DisallowedContent' => 'Votre mot de passe ne peut contenir aucun de ceux-ci: {labelList} (code 180)',
     'Password.MissingPassword' => 'Mot de passe requis',
     'Password.PasswordReuse' => 'Impossible de mettre à jour le mot de passe. Si ce mot de passe a déjà été utilisé, veuillez utiliser quelque chose de différent.',

--- a/application/frontend/messages/ko/app.php
+++ b/application/frontend/messages/ko/app.php
@@ -42,6 +42,7 @@ return [
     'Multiple.SetPartialSuccess' => '{successes} 에서 비밀번호를 설정했지만 {errors} 에서 비밀번호를 설정하지 못했습니다. 도움이 필요하면 {supportName} 시 {supportEmail} 에 문의하십시오.',
     'Multiple.SetFailed' => '비밀번호를 {errors} 으로 설정하지 못했습니다. 도움을 청하기 위해 {supportName} 의 {supportEmail} 로 문의하십시오.',
     'Password.Breached' => '입력 한 비밀번호는 이전에 다른 웹 사이트의 데이터 유출로 발견되었습니다. 귀하의 계좌가 손상되었을 수도 있고 아닐 수도 있습니다. 여기에 다른 암호를 사용하고 방문하시기 바랍니다 <a href="https://sites.google.com/sil.org/identityaccounts/logging-in/password-recommendations" target="_blank">이 도움말 페이지</a> 자세한 내용은.',
+    'Password.ContainsBadByte' => '비밀번호에 허용되지 않는 문자가 포함되어 있습니다.',
     'Password.DisallowedContent' => '귀하의 비밀번호는 다음을 포함하지 않을 수 있습니다 : {labelList} (코드 180)',
     'Password.MissingPassword' => '비밀번호가 필요합니다.',
     'Password.PasswordReuse' => '비밀번호를 업데이트 할 수 없습니다. 이 암호를 사용하기 전에 다른 것을 사용하십시오.',

--- a/application/tests/unit/common/models/PasswordTest.php
+++ b/application/tests/unit/common/models/PasswordTest.php
@@ -113,6 +113,19 @@ class PasswordTest extends Test
         }
     }
 
+    public function testBadBytes()
+    {
+        $employeeId = '111111';
+        $user = User::findOne(['employee_id' => $employeeId]);
+
+        $badPassword = "1" . "\0" . "23456";
+        $password = Password::create($user, $badPassword);
+        $password->validate();
+        $errors = join('|', array_values($password->getErrors('password')));
+        $msg = sprintf('Failed validating test for bad bytes in password. (Errors: "%s")', $errors);
+        $this->assertTrue(str_contains($errors, 'Password.ContainsBadByte'), $msg);
+    }
+
     private function getTestData()
     {
         return [


### PR DESCRIPTION
### Security
- Added password validation to reject a password containing a null byte.

[IDP-125](https://itse.youtrack.cloud/issue/IDP-125)

---

### Feature PR Checklist
- [x] Documentation (README, etc.)
- [x] Unit tests created or updated
- [x] Run `make composershow`
