### PR TITLE
IDP-1076: Add option to require alpha and numeric chars for PCI 4.0 compliance

### DIFF
--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -59,6 +59,7 @@ $passwordRules = [
     'maxLength' => $passwordRulesEnv['maxLength'] ?? 255,
     'minScore' => $passwordRulesEnv['minScore'] ?? 3,
     'enableHIBP' => $passwordRulesEnv['enableHIBP'] ?? true,
+    'requireAlphaAndNumeric' => $passwordRulesEnv['requireAlphaAndNumeric'] ?? false,
 ];
 
 $logPrefix = function () {

--- a/application/common/models/Password.php
+++ b/application/common/models/Password.php
@@ -87,7 +87,14 @@ class Password extends Model
             [
                 'password', 'validateNoBadBytes',
                 'skipOnError' => false,
-            ]
+            ],
+            [
+                'password', 'validateAlphaAndNumeric',
+                'skipOnError' => false,
+                'when' => function () {
+                    return $this->config['requireAlphaAndNumeric'];
+                },
+            ],
         ];
     }
 
@@ -286,6 +293,20 @@ class Password extends Model
     {
         if (str_contains($this->$attribute, "\0")) {
             $this->addError($attribute, \Yii::t('app', 'Password.ContainsBadByte'));
+        }
+    }
+
+    public function validateAlphaAndNumeric($attribute)
+    {
+        $letter = preg_match('/\pL/', $this->$attribute);
+        $number = preg_match('/\pN/', $this->$attribute);
+
+        if ($letter === false || $number === false) {
+            throw new \Exception('Password.UnknownProblem');
+        }
+
+        if ($letter === 0 || $number === 0) {
+            $this->addError($attribute, \Yii::t('app', 'Password.AlphaAndNumericRequired'));
         }
     }
 }

--- a/application/common/models/Password.php
+++ b/application/common/models/Password.php
@@ -296,7 +296,7 @@ class Password extends Model
         }
     }
 
-    public function validateAlphaAndNumeric($attribute)
+    public function validateAlphaAndNumeric(string $attribute): void
     {
         $letter = preg_match('/\pL/', $this->$attribute);
         $number = preg_match('/\pN/', $this->$attribute);

--- a/application/frontend/messages/en/app.php
+++ b/application/frontend/messages/en/app.php
@@ -41,6 +41,7 @@ return [
     'Mfa.VerifyFailure' => 'MFA verify failure',
     'Multiple.SetPartialSuccess' => 'Successfully set the password in {successes}, but failed to set the password in {errors}. Contact {supportName} at {supportEmail} for assistance.',
     'Multiple.SetFailed' => 'Failed to set the password in {errors}. Contact {supportName} at {supportEmail} for assistance.',
+    'Password.AlphaAndNumericRequired' => 'Your password needs to include both a letter and a number.',
     'Password.Breached' => 'The password you entered was previously discovered in a data breach of a different website. It may or may not have been your own account that was compromised. Please use a different password here and then visit <a href="https://sites.google.com/sil.org/identityaccounts/logging-in/password-recommendations" target="_blank">this help page</a> to learn more.',
     'Password.ContainsBadByte' => 'Password contains a disallowed character',
     'Password.DisallowedContent' => 'Your password may not contain any of these: {labelList} (code 180)',

--- a/application/frontend/messages/es/app.php
+++ b/application/frontend/messages/es/app.php
@@ -41,6 +41,7 @@ return [
     'Mfa.VerifyFailure' => 'MFA verificar fallo',
     'Multiple.SetPartialSuccess' => 'Estableció correctamente la contraseña en {successes}, pero no pudo establecer la contraseña en {errors}. Póngase en contacto con {supportName} en {supportEmail} para obtener ayuda.',
     'Multiple.SetFailed' => 'Error al establecer la contraseña en {errors}. Póngase en contacto con {supportName} en {supportEmail} para obtener ayuda.',
+    'Password.AlphaAndNumericRequired' => 'Su contraseña debe incluir tanto una letra como un número.',
     'Password.Breached' => 'La contraseña que ingresó fue descubierta previamente en una violación de datos de un sitio web diferente. Puede o no haber sido su propia cuenta la que se vio comprometida. Utilice una contraseña diferente aquí y luego visite <a href="https://sites.google.com/sil.org/identityaccounts/logging-in/password-recommendations" target="_blank">esta página de ayuda</a> para obtener más información.',
     'Password.ContainsBadByte' => 'La contraseña contiene un carácter no permitido',
     'Password.DisallowedContent' => 'Su contraseña no puede contener ninguno de estos: {labelList} (código 180)',

--- a/application/frontend/messages/fr/app.php
+++ b/application/frontend/messages/fr/app.php
@@ -41,6 +41,7 @@ return [
     'Mfa.VerifyFailure' => 'MFA vérifier l\'échec',
     'Multiple.SetPartialSuccess' => 'Le mot de passe a été bien défini sur {successes}, mais pas sur {errors}. Contactez {supportName} à {supportEmail} pour obtenir de l\'aide.',
     'Multiple.SetFailed' => 'Impossible de définir le mot de passe sur {errors}. Contactez {supportName} à {supportEmail} pour obtenir de l\'aide.',
+    'Password.AlphaAndNumericRequired' => 'Votre mot de passe doit inclure à la fois une lettre et un chiffre.',
     'Password.Breached' => 'Le mot de passe que vous avez entré a déjà été découvert dans une violation de données d\'un site Web différent. Votre compte a peut-être été compromis ou non. Veuillez utiliser un mot de passe différent ici, puis visitez <a href="https://sites.google.com/sil.org/identityaccounts/logging-in/password-recommendations" target="_blank">cette page d’aide</a> pour en savoir plus.',
     'Password.ContainsBadByte' => 'Le mot de passe contient un caractère non autorisé',
     'Password.DisallowedContent' => 'Votre mot de passe ne peut contenir aucun de ceux-ci: {labelList} (code 180)',

--- a/application/frontend/messages/ko/app.php
+++ b/application/frontend/messages/ko/app.php
@@ -41,6 +41,7 @@ return [
     'Mfa.VerifyFailure' => 'MFA 확인 실패',
     'Multiple.SetPartialSuccess' => '{successes} 에서 비밀번호를 설정했지만 {errors} 에서 비밀번호를 설정하지 못했습니다. 도움이 필요하면 {supportName} 시 {supportEmail} 에 문의하십시오.',
     'Multiple.SetFailed' => '비밀번호를 {errors} 으로 설정하지 못했습니다. 도움을 청하기 위해 {supportName} 의 {supportEmail} 로 문의하십시오.',
+    'Password.AlphaAndNumericRequired' => '비밀번호에는 문자와 숫자가 모두 포함되어야 합니다.',
     'Password.Breached' => '입력 한 비밀번호는 이전에 다른 웹 사이트의 데이터 유출로 발견되었습니다. 귀하의 계좌가 손상되었을 수도 있고 아닐 수도 있습니다. 여기에 다른 암호를 사용하고 방문하시기 바랍니다 <a href="https://sites.google.com/sil.org/identityaccounts/logging-in/password-recommendations" target="_blank">이 도움말 페이지</a> 자세한 내용은.',
     'Password.ContainsBadByte' => '비밀번호에 허용되지 않는 문자가 포함되어 있습니다.',
     'Password.DisallowedContent' => '귀하의 비밀번호는 다음을 포함하지 않을 수 있습니다 : {labelList} (코드 180)',

--- a/application/tests/unit/common/models/PasswordTest.php
+++ b/application/tests/unit/common/models/PasswordTest.php
@@ -134,7 +134,7 @@ class PasswordTest extends Test
         $passwords = [
             "123456" => false,
             "abcdef" => false,
-            "üüơüāé" => false,
+            "éiéīơ" => false,
             "abc1234567" => true,
             "123abcdefh" => true,
             "1ü31232354" => true,

--- a/application/tests/unit/common/models/PasswordTest.php
+++ b/application/tests/unit/common/models/PasswordTest.php
@@ -151,7 +151,7 @@ class PasswordTest extends Test
                 $msg = sprintf('failed validating password for requiring alpha and numeric with good password "%s". (Errors: "%s")', $password, $errors);
                 $this->assertEmpty($errors, $msg);
             } else {
-                $msg = sprintf('Failed validating test for requiring alpha and numeric in password "%s". (Errors: "%s")', $errors);
+                $msg = sprintf('Failed validating test for requiring alpha and numeric in password "%s". (Errors: "%s")', $password, $errors);
                 $this->assertStringContainsString('Password.AlphaAndNumericRequired', $errors, $msg);
             }
         }

--- a/application/tests/unit/common/models/PasswordTest.php
+++ b/application/tests/unit/common/models/PasswordTest.php
@@ -152,7 +152,7 @@ class PasswordTest extends Test
                 $this->assertEmpty($errors, $msg);
             } else {
                 $msg = sprintf('Failed validating test for requiring alpha and numeric in password. (Errors: "%s")', $errors);
-                $this->assertContains($errors, 'Password.AlphaAndNumericRequired', $msg);
+                $this->assertStringContainsString($errors, 'Password.AlphaAndNumericRequired', $msg);
             }
         }
     }

--- a/application/tests/unit/common/models/PasswordTest.php
+++ b/application/tests/unit/common/models/PasswordTest.php
@@ -141,17 +141,17 @@ class PasswordTest extends Test
             "12345¨" => true,
         ];
 
-        foreach ($passwords as $password => $good) {
-            $password = Password::create($user, $password);
+        foreach ($passwords as $pw => $good) {
+            $password = Password::create($user, $pw);
             $password->config['requireAlphaAndNumeric'] = true;
             $password->validate();
 
             $errors = join('|', array_values($password->getErrors('password')));
             if ($good) {
-                $msg = sprintf('failed validating password for requiring alpha and numeric with good password "%s". (Errors: "%s")', $password, $errors);
+                $msg = sprintf('failed validating password for requiring alpha and numeric with good password "%s". (Errors: "%s")', $pw, $errors);
                 $this->assertEmpty($errors, $msg);
             } else {
-                $msg = sprintf('Failed validating test for requiring alpha and numeric in password "%s". (Errors: "%s")', $password, $errors);
+                $msg = sprintf('Failed validating test for requiring alpha and numeric in password "%s". (Errors: "%s")', $pw, $errors);
                 $this->assertStringContainsString('Password.AlphaAndNumericRequired', $errors, $msg);
             }
         }

--- a/application/tests/unit/common/models/PasswordTest.php
+++ b/application/tests/unit/common/models/PasswordTest.php
@@ -152,7 +152,7 @@ class PasswordTest extends Test
                 $this->assertEmpty($errors, $msg);
             } else {
                 $msg = sprintf('Failed validating test for requiring alpha and numeric in password. (Errors: "%s")', $errors);
-                $this->assertStringContainsString($errors, 'Password.AlphaAndNumericRequired', $msg);
+                $this->assertStringContainsString('Password.AlphaAndNumericRequired', $errors, $msg);
             }
         }
     }

--- a/application/tests/unit/common/models/PasswordTest.php
+++ b/application/tests/unit/common/models/PasswordTest.php
@@ -134,11 +134,11 @@ class PasswordTest extends Test
         $passwords = [
             "123456" => false,
             "abcdef" => false,
-            "abc123" => false,
             "üüơüāé" => false,
-            "123abc" => true,
-            "1ü3123" => true,
-            "12345¨" => true,
+            "abc1234567" => true,
+            "123abcdefh" => true,
+            "1ü31232354" => true,
+            "123452346¨" => true,
         ];
 
         foreach ($passwords as $pw => $good) {

--- a/application/tests/unit/common/models/PasswordTest.php
+++ b/application/tests/unit/common/models/PasswordTest.php
@@ -135,9 +135,9 @@ class PasswordTest extends Test
             "123456" => false,
             "abcdef" => false,
             "abc123" => false,
+            "üüơüāé" => false,
             "123abc" => true,
             "1ü3123" => true,
-            "üüơüāé" => false,
             "12345¨" => true,
         ];
 
@@ -148,10 +148,10 @@ class PasswordTest extends Test
 
             $errors = join('|', array_values($password->getErrors('password')));
             if ($good) {
-                $msg = sprintf('failed validating password with good password %s. (Errors: "%s")', $password, $errors);
+                $msg = sprintf('failed validating password for requiring alpha and numeric with good password "%s". (Errors: "%s")', $password, $errors);
                 $this->assertEmpty($errors, $msg);
             } else {
-                $msg = sprintf('Failed validating test for requiring alpha and numeric in password. (Errors: "%s")', $errors);
+                $msg = sprintf('Failed validating test for requiring alpha and numeric in password "%s". (Errors: "%s")', $errors);
                 $this->assertStringContainsString('Password.AlphaAndNumericRequired', $errors, $msg);
             }
         }

--- a/application/tests/unit/common/models/PasswordTest.php
+++ b/application/tests/unit/common/models/PasswordTest.php
@@ -134,11 +134,11 @@ class PasswordTest extends Test
         $passwords = [
             "123456" => false,
             "abcdef" => false,
-            "éiéīơ" => false,
-            "abc1234567" => true,
-            "123abcdefh" => true,
-            "1ü31232354" => true,
-            "123452346¨" => true,
+            "éiéīơẖ" => false,
+            "abc123" => true,
+            "123abc" => true,
+            "1ü3123" => true,
+            "12345¨" => true,
         ];
 
         foreach ($passwords as $pw => $good) {
@@ -149,7 +149,7 @@ class PasswordTest extends Test
             $errors = join('|', array_values($password->getErrors('password')));
             if ($good) {
                 $msg = sprintf('failed validating password for requiring alpha and numeric with good password "%s". (Errors: "%s")', $pw, $errors);
-                $this->assertEmpty($errors, $msg);
+                $this->assertStringNotContainsString('Password.AlphaAndNumericRequired', $errors, $msg);
             } else {
                 $msg = sprintf('Failed validating test for requiring alpha and numeric in password "%s". (Errors: "%s")', $pw, $errors);
                 $this->assertStringContainsString('Password.AlphaAndNumericRequired', $errors, $msg);

--- a/local.env.dist
+++ b/local.env.dist
@@ -144,12 +144,14 @@ WEBAUTHN_RP_ORIGIN=
 # Minimum ZXCVBN password score, default=3
 #PASSWORD_RULE_minScore=3
 
-# URL of ZXCVBN service, required
-#ZXCVBN_API_BASEURL=
-
 # Enable haveibeenpwned.com password check, default is true
 #PASSWORD_RULE_enableHIBP=true
 
+# Require both Alpha and Numeric characters, default is false
+#PASSWORD_RULE_requireAlphaAndNumeric=false
+
+# URL of ZXCVBN service, required
+#ZXCVBN_API_BASEURL=
 
 # === Authentication component ===
 


### PR DESCRIPTION
### Added
- Add validation option to require alpha and numeric chars

Note: Reference for regex is [here](https://www.php.net/manual/en/regexp.reference.unicode.php).

---

### Feature PR Checklist
- [ ] Documentation (README, etc.)
- [x] Unit tests created or updated
- [ ] Run `make composershow`
