### PR TITLE
Release 7.0.5 -- test on all branches, but only push image for tags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @silinternational/developers
+*.php @silinternational/php-devs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+paste_backlog_issue_link_here
+
+---
+
 ### Added
 - 
 
@@ -18,7 +22,9 @@
 
 ---
 
-### Feature PR Checklist
+### PR Checklist
+
+- [ ] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
 - [ ] Documentation (README, etc.)
 - [ ] Unit tests created or updated
 - [ ] Run `make composershow`

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -2,8 +2,6 @@ name: Test and Publish
 
 on:
   push:
-    branches: [ 'main' ] #Trigger on Push event to 'main' branch 
-    tags: [ '[0-9]+.[0-9]+.[0-9]+'] # Trigger for the version tags '1.0.1'
 
 jobs:
   tests:
@@ -24,6 +22,7 @@ jobs:
     name: Build and Publish
     needs: tests
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
     timeout-minutes: ${{ fromJSON(vars.DEFAULT_JOB_TIMEOUT_MINUTES) }}
     steps:
       - name: Checkout code
@@ -47,12 +46,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-           ${{ vars.DOCKER_ORG }}/${{ github.event.repository.name }}
-           ghcr.io/${{ github.repository }}
+            ${{ vars.DOCKER_ORG }}/${{ github.event.repository.name }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
### Added
- Also push a major-version tag 

### Fixed
- Run CI tests on all branches

