### PR TITLE
encode the array before assigning it to 'error'

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -693,7 +693,7 @@ class User extends UserBase implements IdentityInterface
             \Yii::error([
                 'action' => $msg,
                 'status' => 'error',
-                'error' => $this->getFirstErrors(),
+                'error' => json_encode($this->getFirstErrors()),
             ]);
             if ($code !== null) {
                 throw new \Exception($msg, $code);


### PR DESCRIPTION
[Sentry Issue](https://itse.sentry.io/issues/6130254845/?project=4506061422264322&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=1)

---

### Fixed
- Fixed array passed as error message
