### PR TITLE
Release 7.1.0 -- add Parameter Store as an alternative to AppConfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN apt-get update -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+ADD https://github.com/silinternational/config-shim/releases/download/v1.2.0/config-shim.gz config-shim.gz
+RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
+
 WORKDIR /data
 
 # Install/cleanup composer dependencies

--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ If that is not an option, you can specify an access token using the `AWS_ACCESS_
 If `PARAMETER_STORE_PATH` is given, AWS Parameter Store will be used. Each parameter in AWS Parameter
 Store is set as an environment variable in the execution environment.
 
-Otherwise, AWS AppConfig will be used. The content of the AppConfig configuration profile takes
-the form of a typical .env file, using `#` for comments and `=` for variable assignment. Any
-variables read from AppConfig will overwrite variables set in the execution environment.
+If `PARAMETER_STORE_PATH` is not given but the AppConfig variables are, AWS AppConfig will be used.
+The content of the AppConfig configuration profile takes the form of a typical .env file, using `#`
+for comments and `=` for variable assignment. Any variables read from AppConfig will overwrite variables
+set in the execution environment.
 
 ### Additional setup
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # idp-pw-api
+
 Backend API for Identity Provider Password Management
 
 ## Dev Requirements
 
 ### Linux
+
 1. Docker >= 1.9.1
 2. Docker Compose >= 1.5
 
 ### Mac
+
 1. Docker for Mac
 
 ## Setup
+
 1. Clone this repo
 2. Copy ```local.env.dist``` to ```local.env``` and ```email.local.env.dist```
    to ```email.local.env``` and update values in each as appropriate.
@@ -26,29 +30,34 @@ Backend API for Identity Provider Password Management
    and update with appropriate settings
 6. Follow operating system specific steps below
 7. You should be able to access the API using a REST client or your browser
-   at http://idp-pw-api.local:8080.
+   at http://idp-pw-api.local:51155.
 8. You'll probably also want the web interface for this application which you can
    clone at <https://github.com/silinternational/idp-profile-ui>
 
 ## Configuration
+
 By default, configuration is read from environment variables. These are documented
-in the `local.env.dist` file. Optionally, you can define configuration in AWS AppConfig.
+in the `local.env.dist` file. Optionally, you can define configuration in AWS Systems Manager.
 To do this, set the following environment variables to point to the configuration in
 AWS:
 
 * `AWS_REGION` - the AWS region in use
-* `APP_ID` - the application ID or name
-* `CONFIG_ID` - the configuration profile ID or name
-* `ENV_ID` - the environment ID or name
+* `APP_ID` - AppConfig application ID or name
+* `CONFIG_ID` - AppConfig configuration profile ID or name
+* `ENV_ID` - AppConfig environment ID or name
+* `PARAMETER_STORE_PATH` - Parameter Store base path for this app, e.g. "/idp-pw-api/idp-name/prod"
 
 In addition, the AWS API requires authentication. It is best to use an access role
 such as an [ECS Task Role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).
 If that is not an option, you can specify an access token using the `AWS_ACCESS_KEY_ID` and
 `AWS_SECRET_ACCESS_KEY` variables.
 
-The content of the configuration profile takes the form of a typical .env file, using
-`#` for comments and `=` for variable assignment. Any variables read from AppConfig
-will overwrite variables set in the execution environment.
+If `PARAMETER_STORE_PATH` is given, AWS Parameter Store will be used. Each parameter in AWS Parameter
+Store is set as an environment variable in the execution environment.
+
+Otherwise, AWS AppConfig will be used. The content of the AppConfig configuration profile takes
+the form of a typical .env file, using `#` for comments and `=` for variable assignment. Any
+variables read from AppConfig will overwrite variables set in the execution environment.
 
 ### Additional setup
 
@@ -57,6 +66,7 @@ will overwrite variables set in the execution environment.
 3. Run ```make start```
 
 ### Makefile script aliases
+
 To simplify common tasks there is a Makefile in place. The most common tasks will likely be:
 
 - ```make start``` - Does what is needed to get API server online
@@ -65,27 +75,42 @@ To simplify common tasks there is a Makefile in place. The most common tasks wil
 - ```make testintegration``` - Runs just the integration tests
 - ```make clean``` - Remove all containers
 - ```make composerupdate``` - ```make start``` will run a ```composer install```, but to update composer
-    you need to run ```make composerupdate```
+  you need to run ```make composerupdate```
 
 **Note:** The CI/CD process only runs the local tests now.
 
 ## Component Architecture
-With the goal of being reusable, this application is developed with a component based architecture that allows swapping out specific components to suit your needs. All components must implement common interfaces to support this and new components can be developed to implement the interface as needed.
+
+With the goal of being reusable, this application is developed with a component based architecture that allows swapping
+out specific components to suit your needs. All components must implement common interfaces to support this and new
+components can be developed to implement the interface as needed.
 
 ### Common Interfaces and Classes
-The interfaces for the following components are stored within the [application/common/components](./application/common/components) source tree.
+
+The interfaces for the following components are stored within
+the [application/common/components](./application/common/components) source tree.
 
 ### Configuration
-All components must extend from [\yii\base\Component](http://www.yiiframework.com/doc-2.0/guide-structure-application-components.html) so that they can be configured in the ```components``` section of the application configuration. This also allows them to be accessed via ```\Yii::$app->componentId```. While each component has a defined interface for methods to implement, what properties it needs for configuration are up to each implementation as appropriate. See [our common/config/local.php.dist](https://github.com/silinternational/idp-pw-api/blob/develop/application/common/config/local.php.dist) for examples of configurations.
+
+All components must extend
+from [\yii\base\Component](http://www.yiiframework.com/doc-2.0/guide-structure-application-components.html) so that they
+can be configured in the ```components``` section of the application configuration. This also allows them to be accessed
+via ```\Yii::$app->componentId```. While each component has a defined interface for methods to implement, what
+properties it needs for configuration are up to each implementation as appropriate.
+See [our common/config/local.php.dist](https://github.com/silinternational/idp-pw-api/blob/develop/application/common/config/local.php.dist)
+for examples of configurations.
 
 ### Authentication Component
-We use SAML for authentication but this component can be replaced to support whatever method is needed. For example an auth component could be written to implement OAuth or use Google, etc.
+
+We use SAML for authentication but this component can be replaced to support whatever method is needed. For example an
+auth component could be written to implement OAuth or use Google, etc.
 
 * Component ID: ```auth```
 * Implement interface: ```common\components\auth\AuthnInterface```
 * [Example implementation](application/common/components/auth/Saml.php)
 
 ### Password Store Component
+
 You can store your passwords wherever you like, whether it is LDAP, Active Directory, a database, or even Redis.
 
 * Component ID: ```passwordstore```
@@ -93,14 +118,18 @@ You can store your passwords wherever you like, whether it is LDAP, Active Direc
 * [Example implementation](application/common/components/passwordStore/Ldap.php)
 
 ### Personnel Component
-The personnel component is used to look up informaton about users from your company's personnel system. This includes verifying that they are an active employee, getting information about them like name, email, employee id, whether they have a supervisor and what their supervisors email address is.
+
+The personnel component is used to look up informaton about users from your company's personnel system. This includes
+verifying that they are an active employee, getting information about them like name, email, employee id, whether they
+have a supervisor and what their supervisors email address is.
 
 * Component ID: ```personnel```
 * Implement interface: ```common\components\personnel\PersonnelInterface```
 * [Example implementation](application/common/components/personnel/IdBroker.php)
 
 ### passwordStore/Google component
- Password store component for IdP PW API that uses Google as the backend.
+
+Password store component for IdP PW API that uses Google as the backend.
 
 #### To Use
 
@@ -144,17 +173,19 @@ comments in the `/application/common/components/passwordStore/Google.php` file.
 
 #### Testing the Google PasswordStore component
 
-If running the Google PasswordStore tests (which are integration tests), you 
+If running the Google PasswordStore tests (which are integration tests), you
 will need to provide credentials in the `local.env file` in the
 `TEST_GOOGLE_...` variables for the values described above. See the
 `local.env.dist` file for the variable names.
 
 ## API Documentation
+
 The API is described by [api.raml](api.raml), and an auto-generated [api.html](api.html) created by
 `raml2html`. To regenerate the HTML file, run `make raml2html`.
 
 ### Quick start for manually interacting with API
-To quickly get up and running to verify basic operation of the API, these are a 
+
+To quickly get up and running to verify basic operation of the API, these are a
 few endpoints to start with. GET endpoints can be exercised with any browser,
 but others will need something like [Insomnia](http://insomnia.rest).
 
@@ -169,9 +200,9 @@ This endpoint verifies connectivity to the database and to the email service.
 #### `POST /reset` and `PUT /reset/{uid}/validate`
 
 This combination requires connection to a PasswordStore component and a Personnel
-component containing a valid user record. After sending the `POST`, retrieve the reset 
+component containing a valid user record. After sending the `POST`, retrieve the reset
 code from the email or the database, and the reset uid from the response body, then
-supply them in the `PUT` request body and URI. The response will contain an 
+supply them in the `PUT` request body and URI. The response will contain an
 `access_token` to use for subsequent calls that require it.
 
 #### `GET /auth/login`
@@ -181,39 +212,40 @@ method is to use an `invite` code, which can be found in the ID Broker database 
 creating a new user. The `access_token` can be found in the `Location` response header.
 
 ## Test configuration
+
 Tests are configured in multiple places, using different test frameworks.
 The chart below summarizes the test configuration.
 
-| Suite | Framework   |  config   | Local, Docker        | GitHub Actions          |
-|-------|-------------|-----------|----------------------|-------------------------|
-| Unit  | PHPUnit     | container | unittest             | api                     |
-|       |             | script    | run-tests.sh         | (same)                  | 
-|       |             | env.      | common.env, test.env | actions-services.yml    |
-|       |             | bootstrap | tests/_bootstrap.php | (same)                  | 
-|       |             | config    | tests/unit.suite.yml, tests/codeception/config/unit.php | (same)                  |
-|       |             | coverage  | IdBroker, IdBrokerPw, Ldap | (same)                  |
-|-------|-------------|-----------|----------------------| ----------------------- |
-| Unit  | Behat       | container | unittest             | api                     |
-|       |             | script    | run-tests.sh         | (same)                  | 
-|       |             | env.      | common.env, test.env | actions-services.yml    |
-|       |             | bootstrap | Composer             | (same)                  |
-|       |             | config    | features/behat.yml   | (same)                  |
-|       |             | coverage  | Multiple, Google     | (same)                  |
-|-------|-------------|-----------|----------------------| ----------------------- |
-| Unit  | Codeception | container | unittest             | api                     |
-|       |             | script    | run-tests.sh         | (same)                  | 
-|       |             | env.      | common.env, test.env | actions-services.yml    |
-|       |             | bootstrap | tests/_bootstrap.php | (same)                  | 
-|       |             | config    | tests/unit.suite.yml | (same)                  |
-|       |             | coverage  | models, helpers      | (same)                  |
-|-------|-------------|-----------|----------------------| ----------------------- |
-| API   | Codeception | container | apitest              | api                     |
-|       |             | script    | run-tests-api.sh     | (same)                  | 
-|       |             | env.      | common.env, test.env | actions-services.yml    |
-|       |             | bootstrap | tests/_bootstrap.php | (same)                  | 
-|       |             | config    | tests/api.suite.yml  | (same)                  |
-|       |             | coverage  | controllers          | (same)                  |
-|-------|-------------|-----------|----------------------| ----------------------- |
+| Suite   | Framework     | config      | Local, Docker                                           | GitHub Actions          |
+|---------|---------------|-------------|---------------------------------------------------------|-------------------------|
+| Unit    | PHPUnit       | container   | unittest                                                | api                     |
+|         |               | script      | run-tests.sh                                            | (same)                  | 
+|         |               | env.        | common.env, test.env                                    | actions-services.yml    |
+|         |               | bootstrap   | tests/_bootstrap.php                                    | (same)                  | 
+|         |               | config      | tests/unit.suite.yml, tests/codeception/config/unit.php | (same)                  |
+|         |               | coverage    | IdBroker, IdBrokerPw, Ldap                              | (same)                  |
+| ------- | ------------- | ----------- | ----------------------                                  | ----------------------- |
+| Unit    | Behat         | container   | unittest                                                | api                     |
+|         |               | script      | run-tests.sh                                            | (same)                  | 
+|         |               | env.        | common.env, test.env                                    | actions-services.yml    |
+|         |               | bootstrap   | Composer                                                | (same)                  |
+|         |               | config      | features/behat.yml                                      | (same)                  |
+|         |               | coverage    | Multiple, Google                                        | (same)                  |
+| ------- | ------------- | ----------- | ----------------------                                  | ----------------------- |
+| Unit    | Codeception   | container   | unittest                                                | api                     |
+|         |               | script      | run-tests.sh                                            | (same)                  | 
+|         |               | env.        | common.env, test.env                                    | actions-services.yml    |
+|         |               | bootstrap   | tests/_bootstrap.php                                    | (same)                  | 
+|         |               | config      | tests/unit.suite.yml                                    | (same)                  |
+|         |               | coverage    | models, helpers                                         | (same)                  |
+| ------- | ------------- | ----------- | ----------------------                                  | ----------------------- |
+| API     | Codeception   | container   | apitest                                                 | api                     |
+|         |               | script      | run-tests-api.sh                                        | (same)                  | 
+|         |               | env.        | common.env, test.env                                    | actions-services.yml    |
+|         |               | bootstrap   | tests/_bootstrap.php                                    | (same)                  | 
+|         |               | config      | tests/api.suite.yml                                     | (same)                  |
+|         |               | coverage    | controllers                                             | (same)                  |
+| ------- | ------------- | ----------- | ----------------------                                  | ----------------------- |
 
 ### Running tests
 

--- a/application/run.sh
+++ b/application/run.sh
@@ -16,10 +16,12 @@ if [[ $APP_ENV == "dev" ]]; then
     apt-get update && apt-get install php-xdebug
 fi
 
-if [[ -z "${APP_ID}" ]]; then
-  apache2ctl -k start -D FOREGROUND
-else
+if [[ $PARAMETER_STORE_PATH ]]; then
+  config-shim --path $PARAMETER_STORE_PATH -k start -D FOREGROUND
+elif [[ $APP_ID ]]; then
   config-shim --app $APP_ID --config $CONFIG_ID --env $ENV_ID apache2ctl -k start -D FOREGROUND
+else
+  apache2ctl -k start -D FOREGROUND
 fi
 
 # endless loop with a wait is needed for the trap to work


### PR DESCRIPTION

### Added
- Added Parameter Store as an alternative to AppConfig

### Fixed
- Fixed incorrect link in README
- README whitespace autoformat corrections

---

### PR Checklist

- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] Documentation (README, etc.)
- [x] ~Unit tests created or updated~
- [x] ~Run `make composershow`~
