### PR TITLE
Release 7.2.1 -- remove config-shim to use the version in the silintl/php8 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,6 @@ RUN apt-get update -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ADD https://github.com/silinternational/config-shim/releases/download/v1.2.0/config-shim.gz config-shim.gz
-RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
-
 WORKDIR /data
 
 # Install/cleanup composer dependencies


### PR DESCRIPTION
### Removed
- Removed config-shim from Dockerfile to use the version in the silintl/php8 base image


### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] ~Documentation (README, etc.)~
- [x] ~Unit tests created or updated~
- [x] ~Run `make composershow`~
