### PR TITLE
Release 7.3.1 -- update simplesamlphp/saml2 to 4.17.0

### DIFF
--- a/application/composer.lock
+++ b/application/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9353b9f4d4fb6cd26339c3b9862f5fd",
+    "content-hash": "58269a6d35f379f1d2d0f120d96da7ef",
     "packages": [
         {
             "name": "behat/gherkin",
@@ -8062,16 +8062,16 @@
         },
         {
             "name": "simplesamlphp/saml2",
-            "version": "v4.16.14",
+            "version": "v4.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/saml2.git",
-                "reference": "fe6c7bdda5e166e326d19d78f230d959ab51d01d"
+                "reference": "bdf16d1021363a0819c35806124a20e74a78c2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/fe6c7bdda5e166e326d19d78f230d959ab51d01d",
-                "reference": "fe6c7bdda5e166e326d19d78f230d959ab51d01d",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/bdf16d1021363a0819c35806124a20e74a78c2c9",
+                "reference": "bdf16d1021363a0819c35806124a20e74a78c2c9",
                 "shasum": ""
             },
             "require": {
@@ -8117,9 +8117,9 @@
             "description": "SAML2 PHP library from SimpleSAMLphp",
             "support": {
                 "issues": "https://github.com/simplesamlphp/saml2/issues",
-                "source": "https://github.com/simplesamlphp/saml2/tree/v4.16.14"
+                "source": "https://github.com/simplesamlphp/saml2/tree/v4.17.0"
             },
-            "time": "2024-12-01T22:26:30+00:00"
+            "time": "2025-03-11T17:35:33+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/application/dependencies.json
+++ b/application/dependencies.json
@@ -453,7 +453,7 @@
   },
   {
     "name": "simplesamlphp/saml2",
-    "version": "v4.16.14"
+    "version": "v4.17.0"
   },
   {
     "name": "swiftmailer/swiftmailer",


### PR DESCRIPTION
[IDP-1475](https://itse.youtrack.cloud/issue/IDP-1475) idp-pw-api alert #27: CVE-2025-27773

---

### Security
- Update simplesamlphp/saml2 to 4.17.0

---

### PR Checklist

- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] ~Documentation (README, etc.)~
- [x] ~Unit tests created or updated~
- [x] Run `make composershow`
