### PR TITLE
Release 7.3.2 -- fix local dev for idp-profile-ui

### DIFF
--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -43,6 +43,9 @@ $emailServiceConfig['validIpRanges'] = Env::getArray('EMAIL_SERVICE_validIpRange
 
 $authClass = Env::get('AUTH_CLASS', 'common\components\auth\Saml');
 $authConfig = Env::getArrayFromPrefix('AUTH_SAML_');
+$authConfig['idpCertificate'] ??= '';
+$authConfig['spCertificate'] ??= '';
+$authConfig['spPrivateKey'] ??= '';
 
 $personnelClass = Env::get('PERSONNEL_CLASS', 'common\components\personnel\IdBroker');
 

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -82,7 +82,7 @@ $logPrefix = function () use ($version) {
     } elseif ($request instanceof \yii\console\Request) {
         $prefixData['id'] = '(console)';
     }
-    
+
     return Json::encode($prefixData);
 };
 
@@ -153,7 +153,7 @@ return [
                         $prefixData = [
                             'env' => YII_ENV,
                         ];
-                        
+
                         // There is no user when a console command is run
                         try {
                             $appUser = \Yii::$app->user;
@@ -163,7 +163,7 @@ return [
                         if ($appUser && !\Yii::$app->user->isGuest) {
                             $prefixData['user'] = \Yii::$app->user->identity->email;
                         }
-                        
+
                         // Try to get requested url and method
                         try {
                             $request = \Yii::$app->request;
@@ -172,7 +172,7 @@ return [
                         } catch (\Exception $e) {
                             $prefixData['url'] = 'not available';
                         }
-                        
+
                         return $prefixData;
                     },
                     'exportInterval' => 1,

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -79,7 +79,7 @@ $logPrefix = function () use ($version) {
     } elseif ($request instanceof \yii\console\Request) {
         $prefixData['id'] = '(console)';
     }
-
+    
     return Json::encode($prefixData);
 };
 
@@ -150,7 +150,7 @@ return [
                         $prefixData = [
                             'env' => YII_ENV,
                         ];
-
+                        
                         // There is no user when a console command is run
                         try {
                             $appUser = \Yii::$app->user;
@@ -160,7 +160,7 @@ return [
                         if ($appUser && !\Yii::$app->user->isGuest) {
                             $prefixData['user'] = \Yii::$app->user->identity->email;
                         }
-
+                        
                         // Try to get requested url and method
                         try {
                             $request = \Yii::$app->request;
@@ -169,7 +169,7 @@ return [
                         } catch (\Exception $e) {
                             $prefixData['url'] = 'not available';
                         }
-
+                        
                         return $prefixData;
                     },
                     'exportInterval' => 1,

--- a/application/run.sh
+++ b/application/run.sh
@@ -15,7 +15,7 @@ echo "starting idp-pw-api version $GITHUB_REF_NAME"
 
 if [[ $APP_ENV == "dev" ]]; then
     export XDEBUG_CONFIG="remote_enable=1 remote_host="$REMOTE_DEBUG_IP
-    apt-get update && apt-get install php-xdebug
+    apt-get update && apt-get install -y php-xdebug
 fi
 
 if [[ $PARAMETER_STORE_PATH ]]; then


### PR DESCRIPTION
[IDP-1476](https://itse.youtrack.cloud/issue/IDP-1476) idp-profile-ui local dev is broken

---


### Fixed
- Fixed an issue that prevented use without SAML certs, which is used during local development in idp-profile-ui.
- Fixed xdebug install by adding the `-y` switch on apt-get


---

### PR Checklist

- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] ~Documentation (README, etc.)~
- [x] ~Unit tests created or updated~
- [x] ~Run `make composershow`~
