### PR TITLE
Release 7.3.4 - Return `LDAP_Entry|array` for findUser calls

### DIFF
--- a/application/common/components/passwordStore/Ldap.php
+++ b/application/common/components/passwordStore/Ldap.php
@@ -284,11 +284,11 @@ class Ldap extends Component implements PasswordStoreInterface
     }
 
     /**
-     * @param LDAP_Entry $user
+     * @param LDAP_Entry|array $user
      * @param string $password
      * @throws \common\components\passwordStore\PasswordReuseException
      */
-    protected function updatePassword(LDAP_Entry $user, string $password): void
+    protected function updatePassword(LDAP_Entry|array $user, string $password): void
     {
         try {
             $user->updateAttribute($this->userPasswordAttribute, $password);
@@ -308,9 +308,9 @@ class Ldap extends Component implements PasswordStoreInterface
     }
 
     /**
-     * @param LDAP_Entry $user
+     * @param LDAP_Entry|array $user
      */
-    protected function removeAttributesAfterNewPassword(LDAP_Entry $user): void
+    protected function removeAttributesAfterNewPassword(LDAP_Entry|array $user): void
     {
         foreach ($this->removeAttributesOnSetPassword as $removeAttr) {
             if ($user->hasAttribute($removeAttr) || $user->hasAttribute(strtolower($removeAttr))) {
@@ -320,9 +320,9 @@ class Ldap extends Component implements PasswordStoreInterface
     }
 
     /**
-     * @param LDAP_Entry $user
+     * @param LDAP_Entry|array $user
      */
-    protected function updateAttributesAfterNewPassword(LDAP_Entry $user): void
+    protected function updateAttributesAfterNewPassword(LDAP_Entry|array $user): void
     {
         foreach ($this->updateAttributesOnSetPassword as $key => $value) {
             if ($user->hasAttribute($key) || $user->hasAttribute(strtolower($key))) {
@@ -334,10 +334,10 @@ class Ldap extends Component implements PasswordStoreInterface
     }
 
     /**
-     * @param LDAP_Entry $user
+     * @param LDAP_Entry|array $user
      * @return bool
      */
-    public function matchesRequiredAttributes(LDAP_Entry $user): bool
+    public function matchesRequiredAttributes(LDAP_Entry|array $user): bool
     {
         // If not defined, just return true to continue processing as normal
         if (! is_array($this->updatePasswordIfAttributeAndValue)) {
@@ -363,10 +363,10 @@ class Ldap extends Component implements PasswordStoreInterface
     }
 
     /**
-     * @param LDAP_Entry $user
+     * @param LDAP_Entry|array $user
      * @throws \common\components\passwordStore\AccountLockedException
      */
-    public function assertUserNotDisabled(LDAP_Entry $user): void
+    public function assertUserNotDisabled(LDAP_Entry|array $user): void
     {
         if ($user->hasAttribute($this->userAccountDisabledAttribute)) {
             $value = $user->getAttribute($this->userAccountDisabledAttribute);
@@ -413,10 +413,10 @@ class Ldap extends Component implements PasswordStoreInterface
 
     /**
      * @param string $employeeId
-     * @return LDAP_Entry
+     * @return LDAP_Entry|array
      * @throws \common\components\passwordStore\UserNotFoundException
      */
-    public function findUser(string $employeeId): LDAP_Entry
+    public function findUser(string $employeeId): LDAP_Entry|array
     {
         $this->connect();
         $criteria = $this->getSearchCriteria();


### PR DESCRIPTION
https://support.gtis.sil.org/issue/IDP-1540


---

### Changed
- findByOrFail returns Model|array, so appending `|array` to the calls and adjusting parameters throughout class.

---

### PR Checklist

- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, etc.)
- [ ] Unit tests created or updated
- [x] Run `make composershow`
