### PR TITLE
correct incompatible default values in inherited function signature

### DIFF
--- a/application/common/components/auth/RedirectException.php
+++ b/application/common/components/auth/RedirectException.php
@@ -2,12 +2,14 @@
 
 namespace common\components\auth;
 
+use Exception;
+
 /**
  * Class RedirectException - Used to trigger a redirect to perform login/logout
  * when IdP uses this method, such as with SAML
  * @package common\components\auth
  */
-class RedirectException extends \Exception
+class RedirectException extends Exception
 {
     /**
      * @var string
@@ -16,12 +18,12 @@ class RedirectException extends \Exception
 
     /**
      * RedirectException constructor.
-     * @param string $url
-     * @param string|null $message
-     * @param int|null $code
-     * @param null|\Exception $previous
+     * @param string $url The URL to target with a redirect.
+     * @param string $message [optional] The Exception message to throw.
+     * @param int $code [optional] The Exception code.
+     * @param Exception|null $previous [optional] The previous throwable used for the exception chaining.
      */
-    public function __construct($url, $message = null, $code = null, \Exception $previous = null)
+    public function __construct(string $url, $message = '', $code = 0, Exception $previous = null)
     {
         $this->url = $url;
         parent::__construct($message, $code, $previous);


### PR DESCRIPTION
### Fixed
- In RedirectException, change the default constructor parameter values to match the parent types.
- Minor documentation fixes